### PR TITLE
Convert to quest IDs for links like requirements and alternatives

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -1,8075 +1,7676 @@
 [
-   {
-      "id":0,
-      "require":{
-         "level":1,
-         "quest":[
-
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Debut",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Debut",
-      "exp":600,
-      "unlocks":[
-         "Kalashnikov AKS-74U 5.45x39"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":5,
-            "location":"Customs",
-            "id":0
-         },
-         {
-            "type":"collect",
-            "target":"MP-133 pump-action shotguns",
-            "number":2,
-            "location":"Any",
-            "id":1
-         }
-      ]
-   },
-   {
-      "id":1,
-      "require":{
-         "level":2,
-         "quest":[
-            "Debut"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Checking",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Checking",
-      "exp":800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Machinery key",
-            "number":1,
-            "location":"Customs",
-            "id":371
-         },
-         {
-            "type":"pickup",
-            "target":"bronze pocket watch",
-            "number":1,
-            "location":"Customs",
-            "id":2
-         }
-      ]
-   },
-   {
-      "id":2,
-      "require":{
-         "level":3,
-         "quest":[
-            "Checking"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Shootout picnic",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Shootout_picnic",
-      "exp":2000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":15,
-            "location":"Woods",
-            "id":3
-         }
-      ]
-   },
-   {
-      "id":3,
-      "require":{
-         "level":5,
-         "quest":[
-            "Checking"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Delivery from the past",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Delivery_from_the_past",
-      "exp":4100,
-      "unlocks":[
-         "5.45x39 mm PS"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.11
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Customs office key",
-            "number":1,
-            "location":"Customs",
-            "id":86
-         },
-         {
-            "type":"pickup",
-            "target":"Secure case for documents 0022",
-            "number":1,
-            "location":"Customs",
-            "id":4
-         },
-         {
-            "type":"place",
-            "target":"Secure case for documents 0022",
-            "number":1,
-            "location":"Factory",
-            "id":5
-         }
-      ]
-   },
-   {
-      "id":4,
-      "require":{
-         "level":5,
-         "quest":[
-            "Delivery from the past"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"BP depot",
-      "wiki":"https://escapefromtarkov.gamepedia.com/BP_depot",
-      "exp":2900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tanker 1",
-            "hint":"Gas station",
-            "number":1,
-            "location":"Customs",
-            "id":6
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tanker 2",
-            "hint":"Old Gas Station",
-            "number":1,
-            "location":"Customs",
-            "id":7
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tanker 3",
-            "hint":"Construction",
-            "number":1,
-            "location":"Customs",
-            "id":8
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tanker 4",
-            "hint":"Garages",
-            "number":1,
-            "location":"Customs",
-            "id":9
-         }
-      ]
-   },
-   {
-      "id":5,
-      "require":{
-         "level":6,
-         "quest":[
-            "BP depot"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Bad rep evidence",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Bad_rep_evidence",
-      "exp":4200,
-      "unlocks":[
-         "Zenit-Belomo PSO 1M2-1 4x24 scope"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Portable cabin key of customs Factory zone",
-            "number":1,
-            "location":"Customs",
-            "id":10
-         },
-         {
-            "type":"pickup",
-            "target":"Secure case for documents 0031",
-            "number":1,
-            "location":"Customs",
-            "id":11
-         }
-      ]
-   },
-   {
-      "id":6,
-      "require":{
-         "level":9,
-         "quest":[
-            "Bad rep evidence"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Ice cream cones",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Ice_cream_cones",
-      "exp":5400,
-      "unlocks":[
-         "60-round 6L31 5.45x39 magazine for AK-74 and compatibles"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"60-round 6L31 5.45x39 magazine for AK-74 and compatibles",
-            "number":3,
-            "location":"Any",
-            "have":0,
-            "id":12
-         }
-      ]
-   },
-   {
-      "id":7,
-      "require":{
-         "level":10,
-         "quest":[
-            "Ice cream cones"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Therapist",
-      "title":"Postman Pat",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Postman_Pat_-_Part_1",
-      "exp":6000,
-      "unlocks":[
-         "Salewa FIRST AID KIT"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Sealed letter",
-            "number":1,
-            "location":"Factory",
-            "id":13
-         }
-      ]
-   },
-   {
-      "id":8,
-      "require":{
-         "level":10,
-         "quest":[
-            "Postman Pat"
-         ],
-         "loyalty":"Prapor2"
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Shaking up teller",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Shaking_up_teller",
-      "exp":6100,
-      "unlocks":[
-         "PBS-4 5.45x39 Silencer",
-         "Hexagon 12K sound suppressor"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Dorm room 203 Key",
-            "number":1,
-            "location":"Customs",
-            "id":14
-         },
-         {
-            "type":"pickup",
-            "target":"Bank case",
-            "number":1,
-            "location":"Customs",
-            "id":15
-         }
-      ]
-   },
-   {
-      "id":9,
-      "require":{
-         "level":35,
-         "quest":[
-            "Shaking up teller"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Perfect mediator",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Perfect_mediator",
-      "exp":17200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"reputation",
-            "target":"Prapor",
-            "number":4,
-            "location":"Any",
-            "id":16
-         },
-         {
-            "type":"reputation",
-            "target":"Therapist",
-            "number":4,
-            "location":"Any",
-            "id":17
-         },
-         {
-            "type":"reputation",
-            "target":"Skier",
-            "number":4,
-            "location":"Any",
-            "id":18
-         },
-         {
-            "type":"reputation",
-            "target":"Peacekeeper",
-            "number":4,
-            "location":"Any",
-            "id":19
-         },
-         {
-            "type":"reputation",
-            "target":"Mechanic",
-            "number":4,
-            "location":"Any",
-            "id":20
-         },
-         {
-            "type":"reputation",
-            "target":"Ragman",
-            "number":4,
-            "location":"Any",
-            "id":21
-         }
-      ]
-   },
-   {
-      "id":10,
-      "require":{
-         "level":30,
-         "quest":[
-            "Shaking up teller"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Grenadier",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Grenadier",
-      "exp":21300,
-      "unlocks":[
-         "8 pcs pack of 9x39 7N12 BP ammo"
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":12,
-            "location":"Any",
-            "with":[
-               "Grenade"
+    {
+        "id": 0,
+        "require": {
+            "level": 1,
+            "quests": []
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Debut",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Debut",
+        "exp": 600,
+        "unlocks": [
+            "Kalashnikov AKS-74U 5.45x39"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 5,
+                "location": "Customs",
+                "id": 0
+            },
+            {
+                "type": "collect",
+                "target": "MP-133 pump-action shotguns",
+                "number": 2,
+                "location": "Any",
+                "id": 1
+            }
+        ]
+    },
+    {
+        "id": 1,
+        "require": {
+            "level": 2,
+            "quests": [
+                0
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Checking",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Checking",
+        "exp": 800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Machinery key",
+                "number": 1,
+                "location": "Customs",
+                "id": 371
+            },
+            {
+                "type": "pickup",
+                "target": "bronze pocket watch",
+                "number": 1,
+                "location": "Customs",
+                "id": 2
+            }
+        ]
+    },
+    {
+        "id": 2,
+        "require": {
+            "level": 3,
+            "quests": [
+                1
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Shootout picnic",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Shootout_picnic",
+        "exp": 2000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 15,
+                "location": "Woods",
+                "id": 3
+            }
+        ]
+    },
+    {
+        "id": 3,
+        "require": {
+            "level": 5,
+            "quests": [
+                1
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Delivery from the past",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Delivery_from_the_past",
+        "exp": 4100,
+        "unlocks": [
+            "5.45x39 mm PS"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.11
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Customs office key",
+                "number": 1,
+                "location": "Customs",
+                "id": 86
+            },
+            {
+                "type": "pickup",
+                "target": "Secure case for documents 0022",
+                "number": 1,
+                "location": "Customs",
+                "id": 4
+            },
+            {
+                "type": "place",
+                "target": "Secure case for documents 0022",
+                "number": 1,
+                "location": "Factory",
+                "id": 5
+            }
+        ]
+    },
+    {
+        "id": 4,
+        "require": {
+            "level": 5,
+            "quests": [
+                3
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "BP depot",
+        "wiki": "https://escapefromtarkov.gamepedia.com/BP_depot",
+        "exp": 2900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tanker 1",
+                "hint": "Gas station",
+                "number": 1,
+                "location": "Customs",
+                "id": 6
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tanker 2",
+                "hint": "Old Gas Station",
+                "number": 1,
+                "location": "Customs",
+                "id": 7
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tanker 3",
+                "hint": "Construction",
+                "number": 1,
+                "location": "Customs",
+                "id": 8
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tanker 4",
+                "hint": "Garages",
+                "number": 1,
+                "location": "Customs",
+                "id": 9
+            }
+        ]
+    },
+    {
+        "id": 5,
+        "require": {
+            "level": 6,
+            "quests": [
+                4
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Bad rep evidence",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Bad_rep_evidence",
+        "exp": 4200,
+        "unlocks": [
+            "Zenit-Belomo PSO 1M2-1 4x24 scope"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Portable cabin key of customs Factory zone",
+                "number": 1,
+                "location": "Customs",
+                "id": 10
+            },
+            {
+                "type": "pickup",
+                "target": "Secure case for documents 0031",
+                "number": 1,
+                "location": "Customs",
+                "id": 11
+            }
+        ]
+    },
+    {
+        "id": 6,
+        "require": {
+            "level": 9,
+            "quests": [
+                5
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Ice cream cones",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Ice_cream_cones",
+        "exp": 5400,
+        "unlocks": [
+            "60-round 6L31 5.45x39 magazine for AK-74 and compatibles"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "60-round 6L31 5.45x39 magazine for AK-74 and compatibles",
+                "number": 3,
+                "location": "Any",
+                "have": 0,
+                "id": 12
+            }
+        ]
+    },
+    {
+        "id": 7,
+        "require": {
+            "level": 10,
+            "quests": [
+                6
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Therapist",
+        "title": "Postman Pat",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Postman_Pat_-_Part_1",
+        "exp": 6000,
+        "unlocks": [
+            "Salewa FIRST AID KIT"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Sealed letter",
+                "number": 1,
+                "location": "Factory",
+                "id": 13
+            }
+        ]
+    },
+    {
+        "id": 8,
+        "require": {
+            "level": 10,
+            "quests": [
+                7
             ],
-            "id":22
-         }
-      ]
-   },
-   {
-      "id":11,
-      "require":{
-         "level":30,
-         "quest":[
-            "Grenadier"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Insomnia",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Insomnia",
-      "exp":18500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":30,
-            "location":"Any",
-            "with":[
-               "Nighttime (22 - 05 hours)"
-            ],
-            "id":23
-         }
-      ]
-   },
-   {
-      "id":12,
-      "require":{
-         "level":30,
-         "quest":[
-            "Grenadier"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Test drive",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Test_drive_-_Part_1",
-      "exp":31000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":5,
-            "location":"Any",
-            "with":[
-               "M1A",
-               "Hybrid 46 silencer",
-               "Trijicon REAP-IR thermal scope"
-            ],
-            "id":24
-         }
-      ]
-   },
-   {
-      "id":13,
-      "require":{
-         "level":17,
-         "quest":[
-            "Shaking up teller"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The Punisher - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_1",
-      "exp":10800,
-      "unlocks":[
-         "SV-98 bolt-action sniper rifle"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":15,
-            "location":"Shoreline",
-            "with":[
-               "AKM"
-            ],
-            "id":25
-         }
-      ]
-   },
-   {
-      "id":14,
-      "require":{
-         "level":18,
-         "quest":[
-            "The Punisher - Part 1"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The Punisher - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_2",
-      "exp":13900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":12,
-            "location":"Shoreline",
-            "with":[
-               "Supressed weapon"
-            ],
-            "id":26
-         },
-         {
-            "type":"find",
-            "target":"Lower half-masks",
-            "number":7,
-            "location":"Any",
-            "id":27
-         }
-      ]
-   },
-   {
-      "id":15,
-      "require":{
-         "level":19,
-         "quest":[
-            "The Punisher - Part 2"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The Punisher - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_3",
-      "exp":12400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         },
-         {
-            "trader":"Skier",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":25,
-            "location":"Customs",
-            "with":[
-               "AKS-74U"
-            ],
-            "id":28
-         }
-      ]
-   },
-   {
-      "id":16,
-      "require":{
-         "level":20,
-         "quest":[
-            "The Punisher - Part 3"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The Punisher - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_4",
-      "exp":19000,
-      "unlocks":[
-         "5.45x39 mm BT"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.12
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":10,
-            "location":"Woods",
-            "with":[
-               "12 gauge shotgun"
-            ],
-            "id":29
-         },
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":10,
-            "location":"Shoreline",
-            "with":[
-               "balaclava",
-               "scav vest"
-            ],
-            "id":30
-         },
-         {
-            "type":"find",
-            "target":"Bars A-2607",
-            "number":5,
-            "location":"Any",
-            "id":31
-         }
-      ]
-   },
-   {
-      "id":17,
-      "require":{
-         "level":20,
-         "quest":[
-            "The Punisher - Part 4"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The Punisher - Part 5",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_5",
-      "exp":19300,
-      "unlocks":[
-         "7.62x39 mm BP"
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":10,
-            "location":"Any",
-            "with":[
-               "PACA vest",
-               "6b47 helmet"
-            ],
-            "id":32
-         },
-         {
-            "type":"find",
-            "target":"AK-74N",
-            "number":1,
-            "location":"Any",
-            "id":33
-         },
-         {
-            "type":"find",
-            "target":"M4A1",
-            "number":1,
-            "location":"Any",
-            "id":34
-         },
-         {
-            "type":"find",
-            "target":"PM pistol",
-            "number":2,
-            "location":"Any",
-            "id":35
-         }
-      ]
-   },
-   {
-      "id":18,
-      "require":{
-         "level":21,
-         "quest":[
-            "The Punisher - Part 5"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The Punisher - Part 6",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_6",
-      "exp":20600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.12
-         },
-         {
-            "trader":"Skier",
-            "rep":0.06
-         },
-         {
-            "trader":"Therapist",
-            "rep":0.15
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":15,
-            "location":"Any",
-            "with":[
-               "SVDS 7.62x54 Sniper rifle"
-            ],
-            "id":36
-         },
-         {
-            "type":"collect",
-            "target":"USEC dogtags",
-            "number":7,
-            "location":"Any",
-            "id":37
-         },
-         {
-            "type":"collect",
-            "target":"BEAR dogtags",
-            "number":7,
-            "location":"Any",
-            "id":38
-         }
-      ]
-   },
-   {
-      "id":19,
-      "require":{
-         "level":1,
-         "quest":[
-
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Shortage",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Shortage",
-      "exp":500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Salewa First Aid Kit",
-            "number":3,
-            "location":"Any",
-            "id":39
-         }
-      ]
-   },
-   {
-      "id":20,
-      "require":{
-         "level":4,
-         "quest":[
-            "Shortage"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Sanitary Standards - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Sanitary_Standards_-_Part_1",
-      "exp":2200,
-      "unlocks":[
-         "Car first aid kit"
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Gas analyzer",
-            "number":1,
-            "location":"Any",
-            "id":40
-         }
-      ]
-   },
-   {
-      "id":21,
-      "require":{
-         "level":8,
-         "quest":[
-            "Sanitary Standards - Part 1"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Sanitary Standards - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Sanitary_Standards_-_Part_2",
-      "exp":4500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Gas analyzer",
-            "number":2,
-            "location":"Any",
-            "id":41
-         }
-      ]
-   },
-   {
-      "id":22,
-      "require":{
-         "level":8,
-         "quest":[
-            "Sanitary Standards - Part 2"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Painkiller",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Painkiller",
-      "exp":4600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Morphine injector",
-            "number":4,
-            "location":"Any",
-            "have":0,
-            "id":42
-         }
-      ]
-   },
-   {
-      "id":23,
-      "require":{
-         "level":10,
-         "quest":[
-            "Painkiller"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Pharmacist",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Pharmacist",
-      "exp":5900,
-      "unlocks":[
-         "6B47 Helmet with cover (flora digital)"
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Dorm room 114 Key",
-            "number":1,
-            "location":"Customs",
-            "id":43
-         },
-         {
-            "type":"pickup",
-            "target":"Carbon case",
-            "number":1,
-            "location":"Customs",
-            "id":44
-         }
-      ]
-   },
-   {
-      "id":24,
-      "require":{
-         "level":13,
-         "quest":[
-            "Pharmacist"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Supply plans",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Supply_plans",
-      "exp":7700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         },
-         {
-            "trader":"Skier",
-            "rep":-0.3
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Secure case for documents 0052",
-            "number":1,
-            "location":"Woods",
-            "id":45
-         }
-      ],
-      "alternative":[
-         "Kind of sabotage"
-      ]
-   },
-   {
-      "id":25,
-      "require":{
-         "level":13,
-         "quest":[
-            "Pharmacist"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Skier",
-      "title":"Kind of sabotage",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Kind_of_sabotage",
-      "exp":4600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":-0.1
-         },
-         {
-            "trader":"Skier",
-            "rep":0.3
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Secure case for documents 0052",
-            "number":1,
-            "location":"Woods",
-            "id":46
-         }
-      ],
-      "alternative":[
-         "Supply plans"
-      ]
-   },
-   {
-      "id":26,
-      "require":{
-         "level":10,
-         "quest":[
-            "Pharmacist"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"General wares",
-      "wiki":"https://escapefromtarkov.gamepedia.com/General_wares",
-      "exp":5000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Can of beef stew",
-            "number":15,
-            "location":"Any",
-            "id":47
-         }
-      ]
-   },
-   {
-      "id":27,
-      "require":{
-         "level":10,
-         "quest":[
-            "Pharmacist"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Car repair",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Car_repair",
-      "exp":7600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Car battery",
-            "number":4,
-            "location":"Any",
-            "have":0,
-            "id":48
-         },
-         {
-            "type":"find",
-            "target":"Spark plug",
-            "number":8,
-            "location":"Any",
-            "have":0,
-            "id":49
-         }
-      ]
-   },
-   {
-      "id":28,
-      "require":{
-         "level":10,
-         "quest":[
-            "Pharmacist"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Health Care Privacy - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_1",
-      "exp":6500,
-      "unlocks":[
-         "IFAK personal tactical first aid kit"
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Ambulance 1",
-            "hint":"Resort",
-            "number":1,
-            "location":"Shoreline",
-            "id":50
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Ambulance 2",
-            "hint":"Tunnel close",
-            "number":1,
-            "location":"Shoreline",
-            "id":51
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Ambulance 3",
-            "hint":"Tunnel far",
-            "number":1,
-            "location":"Shoreline",
-            "id":52
-         }
-      ]
-   },
-   {
-      "id":29,
-      "require":{
-         "level":10,
-         "quest":[
-            "Health Care Privacy - Part 1"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Health Care Privacy - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_2",
-      "exp":8600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"West wing room 306 key",
-            "number":1,
-            "location":"Shoreline",
-            "id":53
-         },
-         {
-            "type":"pickup",
-            "target":"Secure case for documents 0060",
-            "number":1,
-            "location":"Shoreline",
-            "id":54
-         }
-      ]
-   },
-   {
-      "id":30,
-      "require":{
-         "level":10,
-         "quest":[
-            "Health Care Privacy - Part 2"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Health Care Privacy - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_3",
-      "exp":9400,
-      "unlocks":[
-         "Morphine injector"
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Blood sample",
-            "number":1,
-            "location":"Woods",
-            "id":55
-         }
-      ]
-   },
-   {
-      "id":31,
-      "require":{
-         "level":10,
-         "quest":[
-            "Health Care Privacy - Part 3"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Health Care Privacy - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_4",
-      "exp":10200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Health",
-            "number":4,
-            "location":"Any",
-            "id":56
-         }
-      ]
-   },
-   {
-      "id":32,
-      "require":{
-         "level":10,
-         "quest":[
-            "Health Care Privacy - Part 4"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Health Care Privacy - Part 5",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_5",
-      "exp":13300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"place",
-            "target":"Gunpowder \"Kite\"",
-            "number":3,
-            "location":"Factory",
-            "id":57
-         }
-      ]
-   },
-   {
-      "id":33,
-      "require":{
-         "level":30,
-         "quest":[
-            "Health Care Privacy - Part 5",
-            "Private clinic"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Decontamination Service",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Decontamination_service",
-      "exp":21600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.11
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":40,
-            "location":"Interchange",
-            "with":[
-               "Respirator OR Gasmask",
-               "Close range"
-            ],
-            "id":58
-         }
-      ]
-   },
-   {
-      "id":34,
-      "require":{
-         "level":35,
-         "quest":[
-            "Health Care Privacy - Part 4"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Private clinic",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Private_clinic",
-      "exp":20100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.11
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Ophthalmoscope",
-            "number":1,
-            "location":"Any",
-            "id":59
-         },
-         {
-            "type":"find",
-            "target":"LEDX Skin Transilluminator",
-            "number":1,
-            "location":"Any",
-            "id":60
-         }
-      ]
-   },
-   {
-      "id":35,
-      "require":{
-         "level":30,
-         "quest":[
-            "Health Care Privacy - Part 4"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Athlete",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Athlete",
-      "exp":19600,
-      "unlocks":[
-         "Adrenaline injector"
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.11
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Health",
-            "number":10,
-            "location":"Any",
-            "id":61
-         }
-      ]
-   },
-   {
-      "id":36,
-      "require":{
-         "level":5,
-         "quest":[]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Supplier",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Supplier",
-      "exp":3300,
-      "unlocks":[
-         "Saiga-9 9x19 Carbine"
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Module-3M bodyarmor",
-            "number":1,
-            "location":"Any",
-            "id":62
-         },
-         {
-            "type":"find",
-            "target":"TOZ-106 bolt-action shotgun",
-            "number":1,
-            "location":"Any",
-            "id":63
-         }
-      ]
-   },
-   {
-      "id":37,
-      "require":{
-         "level":7,
-         "quest":[
-            "Supplier"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"The Extortionist",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Extortionist",
-      "exp":3200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Unknown key",
-            "number":1,
-            "location":"Customs",
-            "id":64
-         },
-         {
-            "type":"pickup",
-            "target":"Docs 0048",
-            "number":1,
-            "location":"Customs",
-            "id":65
-         }
-      ]
-   },
-   {
-      "id":38,
-      "require":{
-         "level":8,
-         "quest":[
-            "The Extortionist"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"What's on the flash drive?",
-      "wiki":"https://escapefromtarkov.gamepedia.com/What%27s_on_the_flash_drive%3F",
-      "exp":4500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.1
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Secure Flash drive",
-            "number":2,
-            "location":"Any",
-            "id":66
-         }
-      ]
-   },
-   {
-      "id":39,
-      "require":{
-         "level":8,
-         "quest":[
-            "What's on the flash drive?"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Golden swag",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Golden_swag",
-      "exp":4600,
-      "unlocks":[
-         "VOMZ Pilad P1X42 \"WEAVER\" reflex sight"
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Dorm room 303 Key",
-            "number":1,
-            "location":"Customs",
-            "id":67
-         },
-         {
-            "type":"key",
-            "target":"Trailer park cabin key",
-            "number":1,
-            "location":"Customs",
-            "id":68
-         },
-         {
-            "type":"pickup",
-            "target":"Gilded Zibbo lighter",
-            "number":1,
-            "location":"Customs",
-            "id":69
-         },
-         {
-            "type":"place",
-            "target":"Gilded Zibbo lighter",
-            "number":1,
-            "location":"Customs",
-            "id":70
-         }
-      ]
-   },
-   {
-      "id":40,
-      "require":{
-         "level":10,
-         "quest":[
-            "Golden swag"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Chemical - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Chemical_-_Part_1",
-      "exp":4800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Dorm room 220 Key",
-            "number":1,
-            "location":"Customs",
-            "id":71
-         },
-         {
-            "type":"pickup",
-            "target":"Docs 0013",
-            "number":1,
-            "location":"Customs",
-            "id":72
-         }
-      ]
-   },
-   {
-      "id":41,
-      "require":{
-         "level":10,
-         "quest":[
-            "Chemical - Part 1"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Chemical - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Chemical_-_Part_2",
-      "exp":4900,
-      "unlocks":[
-         "SAI-02 10-round 12x76 magazine for SOK-12 and compatible weapons"
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Dorm room 220 Key",
-            "number":1,
-            "location":"Customs",
-            "id":73
-         },
-         {
-            "type":"pickup",
-            "target":"Sealed letter (TerraGroup)",
-            "number":1,
-            "location":"Customs",
-            "id":74
-         },
-         {
-            "type":"pickup",
-            "target":"Sliderkey Secure Flash drive",
-            "number":1,
-            "location":"Customs",
-            "id":75
-         }
-      ]
-   },
-   {
-      "id":42,
-      "require":{
-         "level":11,
-         "quest":[
-            "Chemical - Part 2"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Chemical - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Chemical_-_Part_3",
-      "exp":5400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.08
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Syringe with a chemical",
-            "number":1,
-            "location":"Factory",
-            "id":76
-         }
-      ]
-   },
-   {
-      "id":43,
-      "require":{
-         "level":11,
-         "quest":[
-            "Chemical - Part 3"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Chemical - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Chemical_-_Part_4",
-      "exp":6600,
-      "unlocks":[
-         "ZSh-1-2M helmet (black)"
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.1
-         },
-         {
-            "trader":"Therapist",
-            "rep":-0.3
-         },
-         {
-            "trader":"Prapor",
-            "rep":-0.15
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Transport van",
-            "number":1,
-            "location":"Customs",
-            "id":77
-         }
-      ],
-      "alternative":[
-         "Out of curiosity",
-         "Big customer"
-      ]
-   },
-   {
-      "id":44,
-      "require":{
-         "level":22,
-         "quest":[
-            "Chemical - Part 3"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"\"Vitamins\" - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22Vitamins%22_-_Part_1",
-      "exp":14100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.1
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Office 112 West wing key",
-            "number":1,
-            "location":"Shoreline",
-            "id":78
-         },
-         {
-            "type":"key",
-            "target":"Key to EMERCOM medical unit",
-            "number":1,
-            "location":"Interchange",
-            "id":79
-         },
-         {
-            "type":"pickup",
-            "target":"Chemical container",
-            "number":1,
-            "location":"Shoreline",
-            "id":80
-         },
-         {
-            "type":"pickup",
-            "target":"Chemical container",
-            "hint": "Mantis",
-            "number":1,
-            "location":"Interchange",
-            "id":81
-         },
-         {
-            "type":"pickup",
-            "target":"Chemical container",
-            "hint": "Emercom",
-            "number":1,
-            "location":"Interchange",
-            "id":82
-         }
-      ]
-   },
-   {
-      "id":45,
-      "require":{
-         "level":22,
-         "quest":[
-            "\"Vitamins\" - Part 1"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"\"Vitamins\" - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22Vitamins%22_-_Part_2",
-      "exp":17200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Respirator",
-            "number":4,
-            "location":"Any",
-            "id":83
-         },
-         {
-            "type":"find",
-            "target":"Medical bloodset",
-            "number":3,
-            "location":"Any",
-            "id":84
-         }
-      ]
-   },
-   {
-      "id":46,
-      "require":{
-         "level":9,
-         "quest":[
-            "Golden swag"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Friend from the West - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Friend_from_the_West_-_Part_1",
-      "exp":10800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.14
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":7,
-            "location":"Any",
-            "with":[
-               "USEC faction"
-            ],
-            "id":303
-         },
-         {
-            "type":"find",
-            "target":"USEC dogtags",
-            "number":7,
-            "location":"Any",
-            "id":85
-         }
-      ]
-   },
-   {
-      "id":47,
-      "require":{
-         "level":9,
-         "quest":[
-            "Friend from the West - Part 1"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Friend from the West - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Friend_from_the_West_-_Part_2",
-      "exp":9200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"collect",
-            "target":"Dollars",
-            "number":6000,
-            "location":"Any",
-            "id":87
-         }
-      ]
-   },
-   {
-      "id":48,
-      "require":{
-         "level":25,
-         "quest":[
-            "Friend from the West - Part 2"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Lend lease - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Lend_lease_-_Part_1",
-      "exp":20000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"West wing room 216",
-            "number":1,
-            "location":"Shoreline",
-            "id":88
-         },
-         {
-            "type":"key",
-            "target":"East wing room 306 OR 308 key",
-            "number":1,
-            "location":"Shoreline",
-            "id":89
-         },
-         {
-            "type":"pickup",
-            "target":"Motor Controller",
-            "hint":"SUV",
-            "number":1,
-            "location":"Woods",
-            "id":90
-         },
-         {
-            "type":"pickup",
-            "target":"Motor Controller",
-            "hint":"By Eastern drone",
-            "number":1,
-            "location":"Shoreline",
-            "id":91
-         },
-         {
-            "type":"pickup",
-            "target":"Motor Controller",
-            "hint":"East 306/308",
-            "number":1,
-            "location":"Shoreline",
-            "id":92
-         },
-         {
-            "type":"pickup",
-            "target":"Single-axis Fiber Optic Gyroscope",
-            "hint":"West 216",
-            "number":1,
-            "location":"Shoreline",
-            "id":93
-         },
-         {
-            "type":"pickup",
-            "target":"Single-axis Fiber Optic Gyroscope",
-            "hint":"Truck bed",
-            "number":1,
-            "location":"Woods",
-            "id":94
-         }
-      ]
-   },
-   {
-      "id":49,
-      "require":{
-         "level":30,
-         "quest":[
-            "Lend lease - Part 1"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Lend lease - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Lend_lease_-_Part_2",
-      "exp":22200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Virtex programmable processor",
-            "number":2,
-            "location":"Any",
-            "id":95
-         },
-         {
-            "type":"find",
-            "target":"Military COFDM wireless Signal Transmitter",
-            "number":1,
-            "location":"Any",
-            "id":96
-         }
-      ]
-   },
-   {
-      "id":50,
-      "require":{
-         "level":30,
-         "quest":[
-            "Lend lease - Part 2"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Peacekeeping mission",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Peacekeeping_mission",
-      "exp":32400,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":12,
-            "location":"Customs",
-            "with":[
-               "UNTAR helmet",
-               "MF-UNTAR armor vest",
-               "Colt M4A1"
-            ],
-            "id":97
-         },
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":12,
-            "location":"Interchange",
-            "with":[
-               "UNTAR helmet",
-               "MF-UNTAR armor vest",
-               "Colt M4A1"
-            ],
-            "id":98
-         },
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":12,
-            "location":"Shoreline",
-            "with":[
-               "UNTAR helmet",
-               "MF-UNTAR armor vest",
-               "Colt M4A1"
-            ],
-            "id":99
-         },
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":12,
-            "location":"Woods",
-            "with":[
-               "UNTAR helmet",
-               "MF-UNTAR armor vest",
-               "Colt M4A1"
-            ],
-            "id":100
-         }
-      ]
-   },
-   {
-      "id":51,
-      "require":{
-         "level":24,
-         "quest":[
-            "Friend from the West - Part 2"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Informed means armed",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Informed_means_armed",
-      "exp":15900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool": "WIFI Camera",
-            "target":"Brutal",
-            "number":1,
-            "location":"Interchange",
-            "id":101
-         },
-         {
-            "type":"mark",
-            "tool": "WIFI Camera",
-            "target":"Pier",
-            "number":1,
-            "location":"Woods",
-            "id":102
-         },
-         {
-            "type":"mark",
-            "tool": "WIFI Camera",
-            "target":"Roadblock",
-            "number":1,
-            "location":"Customs",
-            "id":103
-         }
-      ]
-   },
-   {
-      "id":52,
-      "require":{
-         "level":27,
-         "quest":[
-            "Informed means armed"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Chumming",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Chumming",
-      "exp":22000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"place",
-            "target":"Golden neck chain",
-            "number":3,
-            "location":"Interchange",
-            "id":104
-         },
-         {
-            "type":"place",
-            "target":"Golden neck chain",
-            "number":3,
-            "location":"Woods",
-            "id":105
-         },
-         {
-            "type":"place",
-            "target":"Golden neck chain",
-            "number":3,
-            "location":"Customs",
-            "id":106
-         },
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":5,
-            "with":[
-               "Between 22 and 10 hours"
-            ],
-            "location":"Interchange",
-            "id":304
-         }
-      ]
-   },
-   {
-      "id":53,
-      "require":{
-         "level":27,
-         "quest":[
-            "Chumming"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Silent caliber",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Silent_caliber",
-      "exp":12900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":20,
-            "location":"Any",
-            "with":[
-               "supressed 12 gauge shotgun"
-            ],
-            "id":107
-         },
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":10,
-            "location":"Any",
-            "with":[
-               "supressed 12 gauge shotgun"
-            ],
-            "id":108
-         }
-      ]
-   },
-   {
-      "id":54,
-      "require":{
-         "level":27,
-         "quest":[
-            "Chumming"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Flint",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Flint",
-      "exp":20000,
-      "unlocks":[
-         "M-2 Tactical Sword"
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Stress Resistance",
-            "number":6,
-            "location":"Any",
-            "id":109
-         }
-      ]
-   },
-   {
-      "id":55,
-      "require":{
-         "level":27,
-         "quest":[
-            "Chumming"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Bullshit",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Bullshit",
-      "exp":29700,
-      "unlocks":[
-         "5 pcs. 12x70 DIPP ammo box"
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"warning",
-            "target":"Do not kill any scavs from quest accept to quest complete",
-            "number":1,
-            "location":"Customs",
-            "id":110
-         },
-         {
-            "type":"pickup",
-            "target":"False flash drive",
-            "number":1,
-            "location":"Customs",
-            "id":111
-         },
-         {
-            "type":"place",
-            "target":"False flash drive",
-            "number":1,
-            "location":"Customs",
-            "id":112
-         },
-         {
-            "type":"place",
-            "target":"Roler submariner gold wrist watch",
-            "number":1,
-            "location":"Customs",
-            "id":113
-         },
-         {
-            "type":"place",
-            "target":"SV-98 bolt-action sniper rifle",
-            "number":1,
-            "location":"Customs",
-            "id":114
-         }
-      ]
-   },
-   {
-      "id":56,
-      "require":{
-         "level":27,
-         "quest":[
-            "Bullshit"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Setup",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Setup",
-      "exp":29300,
-      "unlocks":[
-         "20 pcs. 9x19 mm DIPP ammo box"
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":15,
-            "location":"Customs",
-            "with":[
-               "MP Series shotgun",
-               "Ushanka ear-flap cap",
-               "Scav vest"
-            ],
-            "id":115
-         }
-      ]
-   },
-   {
-      "id":57,
-      "require":{
-         "level":10,
-         "quest":[
-            "Friend from the West - Part 2"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Fishing Gear",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Fishing_Gear",
-      "exp":5400,
-      "unlocks":[
-         "Aimpoint Micro T-1 reflex sight"
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"place",
-            "target":"SV-98 bolt-action sniper rifle",
-            "number":1,
-            "location":"Shoreline",
-            "id":116
-         },
-         {
-            "type":"place",
-            "target":"Leatherman Multitool",
-            "number":1,
-            "location":"Shoreline",
-            "id":117
-         }
-      ]
-   },
-   {
-      "id":58,
-      "require":{
-         "level":10,
-         "quest":[
-            "Fishing Gear"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Tigr Safari",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Tigr_Safari",
-      "exp":6600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tigr vehicle 1",
-            "hint": "Checkpoint",
-            "number":1,
-            "location":"Customs",
-            "id":118
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tigr vehicle 2",
-            "hint": "Gas station",
-            "number":1,
-            "location":"Customs",
-            "id":119
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tigr vehicle 3",
-            "hint": "Bridge",
-            "number":1,
-            "location":"Customs",
-            "id":120
-         }
-      ]
-   },
-   {
-      "id":59,
-      "require":{
-         "level":10,
-         "quest":[
-            "Tigr Safari"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Scrap Metal",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Scrap_Metal",
-      "exp":7200,
-      "unlocks":[
-         "HK MP5 9x19 submachinegun (Navy 3 Round Burst) \"SD\""
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"T-90 tank 1",
-            "hint": "Bunker",
-            "number":1,
-            "location":"Shoreline",
-            "id":121
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"T-90 tank 2",
-            "hint": "Town",
-            "number":1,
-            "location":"Shoreline",
-            "id":122
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"T-90 tank 3",
-            "hint": "Weather station",
-            "number":1,
-            "location":"Shoreline",
-            "id":123
-         }
-      ]
-   },
-   {
-      "id":60,
-      "require":{
-         "level":11,
-         "quest":[
-            "Scrap Metal"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Eagle Eye",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Eagle_Eye",
-      "exp":7300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"SAS disk 1",
-            "hint": "East Drone",
-            "number":1,
-            "location":"Shoreline",
-            "id":124
-         },
-         {
-            "type":"pickup",
-            "target":"SAS disk 2",
-            "hint": "North Drone",
-            "number":1,
-            "location":"Shoreline",
-            "id":125
-         }
-      ]
-   },
-   {
-      "id":61,
-      "require":{
-         "level":11,
-         "quest":[
-            "Eagle Eye"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Humanitarian Supplies",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Humanitarian_Supplies",
-      "exp":7400,
-      "unlocks":[
-         "Hexagon AK-74 5.45x39 sound suppressor"
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Un cargo truck 1",
-            "number":1,
-            "location":"Shoreline",
-            "id":126
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Un cargo truck 2",
-            "number":1,
-            "location":"Shoreline",
-            "id":127
-         },
-         {
-            "type":"collect",
-            "target":"MRE lunch box",
-            "number":5,
-            "location":"Any",
-            "id":128
-         },
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":10,
-            "location":"Shoreline",
-            "with":[
-               "MF-UNTAR armor vest",
-               "UNTAR helmet"
-            ],
-            "id":129
-         }
-      ]
-   },
-   {
-      "id":62,
-      "require":{
-         "level":12,
-         "quest":[
-            "Humanitarian Supplies"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"The Cult - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Cult_-_Part_1",
-      "exp":6700,
-      "unlocks":[
-         "5.56x45 mm M856A1"
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"The missing informant",
-            "number":1,
-            "location":"Shoreline",
-            "id":130
-         }
-      ]
-   },
-   {
-      "id":63,
-      "require":{
-         "level":12,
-         "quest":[
-            "The Cult - Part 1"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"The Cult - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Cult_-_Part_2",
-      "exp":8200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Marked key",
-            "number":1,
-            "location":"Customs",
-            "id":131
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Ritual spot",
-            "number":1,
-            "location":"Shoreline",
-            "id":132
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Ritual spot 1",
-            "hint": "Cabins",
-            "number":1,
-            "location":"Woods",
-            "id":133
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Ritual spot 2",
-            "hint": "Checkpoint",
-            "number":1,
-            "location":"Woods",
-            "id":268
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Ritual spot",
-            "number":1,
-            "location":"Customs",
-            "id":134
-         }
-      ]
-   },
-   {
-      "id":64,
-      "require":{
-         "level":12,
-         "quest":[
-            "Humanitarian Supplies"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Spa Tour - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_1",
-      "exp":8900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":7,
-            "location":"Shoreline",
-            "with":[
-               "12 gauge shotgun headshots"
-            ],
-            "id":135
-         }
-      ]
-   },
-   {
-      "id":65,
-      "require":{
-         "level":12,
-         "quest":[
-            "Spa Tour - Part 1"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Spa Tour - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_2",
-      "exp":7500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Helicopter",
-            "number":1,
-            "location":"Shoreline",
-            "id":136
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Safe road",
-            "number":1,
-            "location":"Shoreline",
-            "id":137
-         }
-      ]
-   },
-   {
-      "id":66,
-      "require":{
-         "level":12,
-         "quest":[
-            "Spa Tour - Part 2"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Spa Tour - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_3",
-      "exp":9100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"WD-40 100ml",
-            "number":1,
-            "location":"Any",
-            "id":138
-         },
-         {
-            "type":"find",
-            "target":"Clin wiper",
-            "number":2,
-            "location":"Any",
-            "id":139
-         },
-         {
-            "type":"find",
-            "target":"Corrugated hose",
-            "number":2,
-            "location":"Any",
-            "id":140
-         },
-         {
-            "type":"find",
-            "target":"Ox bleach",
-            "number":2,
-            "location":"Any",
-            "id":141
-         }
-      ]
-   },
-   {
-      "id":67,
-      "require":{
-         "level":12,
-         "quest":[
-            "Spa Tour - Part 3"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Spa Tour - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_4",
-      "exp":9300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"West wing room 219 OR 220 key",
-            "number":1,
-            "location":"Shoreline",
-            "id":142
-         },
-         {
-            "type":"locate",
-            "target":"Generator 1",
-            "number":1,
-            "location":"Shoreline",
-            "id":143
-         },
-         {
-            "type":"locate",
-            "target":"Generator 2",
-            "number":1,
-            "location":"Shoreline",
-            "id":144
-         }
-      ]
-   },
-   {
-      "id":68,
-      "require":{
-         "level":12,
-         "quest":[
-            "Spa Tour - Part 4"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Spa Tour - Part 5",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_5",
-      "exp":7800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"The key to the closed premises of the sanatorium",
-            "number":1,
-            "location":"Shoreline",
-            "id":145
-         }
-      ]
-   },
-   {
-      "id":69,
-      "require":{
-         "level":12,
-         "quest":[
-            "Spa Tour - Part 5"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Spa Tour - Part 6",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_6",
-      "wiki":"",
-      "exp":11400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"collect",
-            "target":"Dollars",
-            "number":8000,
-            "location":"Any",
-            "id":146
-         }
-      ]
-   },
-   {
-      "id":70,
-      "require":{
-         "level":12,
-         "quest":[
-            "Spa Tour - Part 6"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Spa Tour - Part 7",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_7",
-      "exp":11600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.09
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Morphine injector",
-            "number":4,
-            "location":"Any",
-            "id":147
-         },
-         {
-            "type":"find",
-            "target":"Heat-exchange alkali surface washer",
-            "number":2,
-            "location":"Any",
-            "id":148
-         },
-         {
-            "type":"find",
-            "target":"Corrugated hose",
-            "number":2,
-            "location":"Any",
-            "id":149
-         },
-         {
-            "type":"find",
-            "target":"5L propane tank",
-            "number":2,
-            "location":"Any",
-            "id":150
-         }
-      ]
-   },
-   {
-      "id":71,
-      "require":{
-         "level":12,
-         "quest":[
-            "Spa Tour - Part 7"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Cargo X - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Cargo_X_-_Part_1",
-      "exp":10400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"East wing room 306 OR 308 key",
-            "number":1,
-            "location":"Shoreline",
-            "id":151
-         },
-         {
-            "type":"pickup",
-            "target":"Toughbook reinforced laptop",
-            "number":1,
-            "location":"Shoreline",
-            "id":152
-         }
-      ]
-   },
-   {
-      "id":72,
-      "require":{
-         "level":12,
-         "quest":[
-            "Cargo X - Part 1"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Cargo X - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Cargo_X_-_Part_2",
-      "exp":8600,
-      "unlocks":[
-         "KAC QDSS NT-4 5.56x45 silencer (Black)"
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Docs 0013",
-            "number":1,
-            "location":"Shoreline",
-            "id":153
-         }
-      ]
-   },
-   {
-      "id":73,
-      "require":{
-         "level":12,
-         "quest":[
-            "Cargo X - Part 2"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Cargo X - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Cargo_X_-_Part_3",
-      "exp":10700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Hidden Terragroup cargo",
-            "number":1,
-            "location":"Shoreline",
-            "id":154
-         }
-      ]
-   },
-   {
-      "id":74,
-      "require":{
-         "level":14,
-         "quest":[
-            "Spa Tour - Part 7"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Wet Job - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_1",
-      "exp":13000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.09
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":10,
-            "location":"Shoreline",
-            "with":[
-               "Supressed M4 or ADAR"
-            ],
-            "id":155
-         }
-      ]
-   },
-   {
-      "id":75,
-      "require":{
-         "level":14,
-         "quest":[
-            "Wet Job - Part 1"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Wet Job - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_2",
-      "exp":11700,
-      "unlocks":[
-         "Magpul PMAG D-60 5.56x45 60-round magazine"
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Fisher's dwelling",
-            "number":1,
-            "location":"Shoreline",
-            "id":156
-         }
-      ]
-   },
-   {
-      "id":76,
-      "require":{
-         "level":14,
-         "quest":[
-            "Wet Job - Part 2"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Wet Job - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_3",
-      "exp":9900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Artyom's car",
-            "number":1,
-            "location":"Shoreline",
-            "id":157
-         }
-      ]
-   },
-   {
-      "id":77,
-      "require":{
-         "level":14,
-         "quest":[
-            "Wet Job - Part 3"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Wet Job - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_4",
-      "exp":10000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Sliderkey Flash drive",
-            "number":1,
-            "location":"Shoreline",
-            "id":158
-         }
-      ]
-   },
-   {
-      "id":78,
-      "require":{
-         "level":14,
-         "quest":[
-            "Wet Job - Part 4"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Wet Job - Part 5",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_5",
-      "exp":10200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"East wing room 328 OR Health resort utility room key",
-            "number":1,
-            "location":"Shoreline",
-            "id":159
-         },
-         {
-            "type":"pickup",
-            "target":"Working hard drive",
-            "number":1,
-            "location":"Shoreline",
-            "id":160
-         }
-      ]
-   },
-   {
-      "id":79,
-      "require":{
-         "level":14,
-         "quest":[
-            "Wet Job - Part 5"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Wet Job - Part 6",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_6",
-      "exp":10400,
-      "unlocks":[
-         "7.62x51 mm M61"
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.06
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Sniper Rifles",
-            "number":7,
-            "location":"Any",
-            "id":161
-         }
-      ]
-   },
-   {
-      "id":80,
-      "require":{
-         "level":40,
-         "quest":[
-            "Wet Job - Part 6"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Psycho Sniper",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Psycho_Sniper",
-      "exp":32400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Sniper Rifles",
-            "number":9,
-            "location":"Any",
-            "id":162
-         }
-      ]
-   },
-   {
-      "id":81,
-      "require":{
-         "level":14,
-         "quest":[
-            "Wet Job - Part 6"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"The guide",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_guide",
-      "exp":35100,
-      "unlocks":[
-         "Eotech HHS-1 sight Tan",
-         "SLAAP armor Plate (Tan)",
-         "Arsenal CWP 30-round 5.56x45 magazine for SLR-106 and compatible weapons"
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":82,
-      "require":{
-         "level":10,
-         "quest":[
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_1",
-      "exp":6500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":83,
-      "require":{
-         "level":11,
-         "quest":[
-            "Gunsmith - Part 1"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_2",
-      "exp":6000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":84,
-      "require":{
-         "level":12,
-         "quest":[
-            "Gunsmith - Part 2"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_3",
-      "exp":8000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":85,
-      "require":{
-         "level":15,
-         "quest":[
-            "Gunsmith - Part 3"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_4",
-      "exp":10100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":86,
-      "require":{
-         "level":17,
-         "quest":[
-            "Gunsmith - Part 4"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 5",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_5",
-      "exp":13900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":87,
-      "require":{
-         "level":18,
-         "quest":[
-            "Gunsmith - Part 5"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 6",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_6",
-      "exp":13900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":88,
-      "require":{
-         "level":19,
-         "quest":[
-            "Gunsmith - Part 6"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 7",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_7",
-      "exp":16000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":89,
-      "require":{
-         "level":19,
-         "quest":[
-            "Gunsmith - Part 7"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 8",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_8",
-      "exp":16200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":90,
-      "require":{
-         "level":20,
-         "quest":[
-            "Gunsmith - Part 8"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 9",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_9",
-      "exp":17300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":91,
-      "require":{
-         "level":20,
-         "quest":[
-            "Gunsmith - Part 9"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 10",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_10",
-      "exp":17500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":92,
-      "require":{
-         "level":20,
-         "quest":[
-            "Gunsmith - Part 10"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 11",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_11",
-      "exp":18600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":93,
-      "require":{
-         "level":23,
-         "quest":[
-            "Gunsmith - Part 11"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 12",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_12",
-      "exp":14400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":94,
-      "require":{
-         "level":25,
-         "quest":[
-            "Gunsmith - Part 12"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 13",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_13",
-      "exp":19000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":95,
-      "require":{
-         "level":27,
-         "quest":[
-            "Gunsmith - Part 13"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 14",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_14",
-      "exp":20800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":96,
-      "require":{
-         "level":29,
-         "quest":[
-            "Gunsmith - Part 14"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 15",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_15",
-      "exp":22600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":97,
-      "require":{
-         "level":35,
-         "quest":[
-            "Gunsmith - Part 15"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Gunsmith - Part 16",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_16",
-      "exp":28500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-
-      ]
-   },
-   {
-      "id":98,
-      "require":{
-         "level":12,
-         "quest":[
-            "Gunsmith - Part 2"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Signal - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Signal_-_Part_1",
-      "exp":8500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"First signal source",
-            "number":1,
-            "location":"Shoreline",
-            "id":163
-         },
-         {
-            "type":"locate",
-            "target":"Second signal source",
-            "number":1,
-            "location":"Shoreline",
-            "id":164
-         }
-      ]
-   },
-   {
-      "id":99,
-      "require":{
-         "level":12,
-         "quest":[
-            "Signal - Part 1"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Signal - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Signal_-_Part_2",
-      "exp":8700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"PC CPU",
-            "number":3,
-            "location":"Any",
-            "id":165
-         },
-         {
-            "type":"find",
-            "target":"Rechargeable battery",
-            "number":3,
-            "location":"Any",
-            "id":166
-         },
-         {
-            "type":"find",
-            "target":"Printed circuit board",
-            "number":3,
-            "location":"Any",
-            "id":167
-         },
-         {
-            "type":"find",
-            "target":"Broken GPhone",
-            "number":3,
-            "location":"Any",
-            "id":168
-         }
-      ]
-   },
-   {
-      "id":100,
-      "require":{
-         "level":15,
-         "quest":[
-            "Signal - Part 2"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Signal - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Signal_-_Part_3",
-      "exp":11000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool": "Signal Jammer",
-            "target":"Antenna 1",
-            "hint": "Weather Station",
-            "number":1,
-            "location":"Shoreline",
-            "id":169
-         },
-         {
-            "type":"mark",
-            "tool": "Signal Jammer",
-            "target":"Antenna 2",
-            "hint": "Radio tower",
-            "number":1,
-            "location":"Shoreline",
-            "id":170
-         },
-         {
-            "type":"mark",
-            "tool": "Signal Jammer",
-            "target":"Antenna 3",
-            "hint": "West Resort Roof",
-            "number":1,
-            "location":"Shoreline",
-            "id":171
-         }
-      ]
-   },
-   {
-      "id":101,
-      "require":{
-         "level":15,
-         "quest":[
-            "Signal - Part 3"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Signal - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Signal_-_Part_4",
-      "exp":11100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Memory",
-            "number":4,
-            "location":"Any",
-            "id":172
-         }
-      ]
-   },
-   {
-      "id":102,
-      "require":{
-         "level":15,
-         "quest":[
-            "Signal - Part 2"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Scout",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Scout",
-      "exp":9200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Factory exit 1",
-            "hint": "Main",
-            "number":1,
-            "location":"Factory",
-            "id":173
-         },
-         {
-            "type":"locate",
-            "target":"Factory exit 2",
-            "hint": "Forlifts",
-            "number":1,
-            "location":"Factory",
-            "id":174
-         },
-         {
-            "type":"locate",
-            "target":"Factory exit 3",
-            "hint": "Staging side",
-            "number":1,
-            "location":"Factory",
-            "id":175
-         }
-      ]
-   },
-   {
-      "id":103,
-      "require":{
-         "level":12,
-         "quest":[
-            "Signal - Part 1",
-            "Gunsmith - Part 3"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Insider",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Insider",
-      "exp":9300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"reputation",
-            "target":"Prapor",
-            "number":3,
-            "location":"Any",
-            "id":176
-         }
-      ]
-   },
-   {
-      "id":104,
-      "require":{
-         "level":12,
-         "quest":[
-            "Gunsmith - Part 1"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Farming - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Farming_-_Part_1",
-      "exp":8000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"place",
-            "target":"A set of tools",
-            "hint": "Forklifts",
-            "number":1,
-            "location":"Factory",
-            "id":177
-         },
-         {
-            "type":"place",
-            "target":"A set of tools",
-            "hint": "Glass hallway",
-            "number":1,
-            "location":"Factory",
-            "id":178
-         }
-      ]
-   },
-   {
-      "id":105,
-      "require":{
-         "level":12,
-         "quest":[
-            "Farming - Part 1"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Farming - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Farming_-_Part_2",
-      "exp":6800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Powercord",
-            "number":2,
-            "location":"Any",
-            "id":179
-         },
-         {
-            "type":"find",
-            "target":"T-Shaped Plug",
-            "number":4,
-            "location":"Any",
-            "id":180
-         },
-         {
-            "type":"find",
-            "target":"Printed circuit board",
-            "number":2,
-            "location":"Any",
-            "id":181
-         }
-      ]
-   },
-   {
-      "id":106,
-      "require":{
-         "level":14,
-         "quest":[
-            "Farming - Part 2"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Farming - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Farming_-_Part_3",
-      "exp":8100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Customs office key",
-            "number":1,
-            "location":"Customs",
-            "id":182
-         },
-         {
-            "type":"pickup",
-            "target":"Package with graphics cards",
-            "number":1,
-            "location":"Customs",
-            "id":183
-         }
-      ]
-   },
-   {
-      "id":107,
-      "require":{
-         "level":14,
-         "quest":[
-            "Farming - Part 3"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Farming - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Farming_-_Part_4",
-      "exp":9800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Graphics card",
-            "number":3,
-            "location":"Any",
-            "id":184
-         },
-         {
-            "type":"find",
-            "target":"CPU Fan",
-            "number":8,
-            "location":"Any",
-            "id":185
-         }
-      ]
-   },
-   {
-      "id":108,
-      "require":{
-         "level":35,
-         "quest":[
-            "Farming - Part 4"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Import",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Import",
-      "exp":42800,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"UHF RFID Reader",
-            "number":1,
-            "location":"Any",
-            "id":186
-         },
-         {
-            "type":"find",
-            "target":"VPX Flash Storage Module",
-            "number":1,
-            "location":"Any",
-            "id":187
-         }
-      ]
-   },
-   {
-      "id":109,
-      "require":{
-         "level":30,
-         "quest":[
-            "Farming - Part 4"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Fertilizers",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Fertilizers",
-      "exp":19500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Wires",
-            "number":5,
-            "location":"Any",
-            "id":188
-         },
-         {
-            "type":"find",
-            "target":"Capacitors",
-            "number":5,
-            "location":"Any",
-            "id":189
-         }
-      ]
-   },
-   {
-      "id":110,
-      "require":{
-         "level":14,
-         "quest":[
-            "Farming - Part 3"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"A Shooter Born in Heaven",
-      "wiki":"https://escapefromtarkov.gamepedia.com/A_Shooter_Born_in_Heaven",
-      "exp":39500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":3,
-            "location":"Woods",
-            "with":[
-               "Headshot from more than 100 meters"
-            ],
-            "id":190
-         },
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":3,
-            "location":"Reserve",
-            "with":[
-               "Headshot from more than 100 meters"
-            ],
-            "id":191
-         },
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":3,
-            "location":"Shoreline",
-            "with":[
-               "Headshot from more than 100 meters"
-            ],
-            "id":192
-         },
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":3,
-            "location":"Customs",
-            "with":[
-               "Headshot from more than 100 meters"
-            ],
-            "id":193
-         }
-      ]
-   },
-   {
-      "id":111,
-      "require":{
-         "level":15,
-         "quest":[
-
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Only business",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Only_business",
-      "exp":6700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"reputation",
-            "target":"Ragman",
-            "number":2,
-            "location":"Any",
-            "id":194
-         }
-      ]
-   },
-   {
-      "id":112,
-      "require":{
-         "level":15,
-         "quest":[
-            "Only business"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Big sale",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Big_sale",
-      "exp":8900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"AVOKADO",
-            "number":1,
-            "location":"Interchange",
-            "id":195
-         },
-         {
-            "type":"locate",
-            "target":"KOSTIN",
-            "number":1,
-            "location":"Interchange",
-            "id":196
-         },
-         {
-            "type":"locate",
-            "target":"tRend",
-            "number":1,
-            "location":"Interchange",
-            "id":197
-         },
-         {
-            "type":"locate",
-            "target":"DINO CLOTHES",
-            "number":1,
-            "location":"Interchange",
-            "id":198
-         },
-         {
-            "type":"locate",
-            "target":"TOP BRAND",
-            "number":1,
-            "location":"Interchange",
-            "id":199
-         }
-      ]
-   },
-   {
-      "id":113,
-      "require":{
-         "level":15,
-         "quest":[
-            "Big sale"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"The Blood of War - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Blood_of_War_-_Part_1",
-      "exp":7500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tanker 1",
-            "hint": "Behind Goshan",
-            "number":1,
-            "location":"Interchange",
-            "id":200
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tanker 2",
-            "hint": "Highway Checkpoint",
-            "number":1,
-            "location":"Interchange",
-            "id":201
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Tanker 3",
-            "hint": "Power Station",
-            "number":1,
-            "location":"Interchange",
-            "id":202
-         }
-      ]
-   },
-   {
-      "id":114,
-      "require":{
-         "level":15,
-         "quest":[
-            "The Blood of War - Part 1"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Dressed to kill",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Dressed_to_kill",
-      "exp":10200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Ushanka ear-flap cap",
-            "number":2,
-            "location":"Any",
-            "id":203
-         },
-         {
-            "type":"find",
-            "target":"Kinda cowboy hat",
-            "number":2,
-            "location":"Any",
-            "id":204
-         }
-      ]
-   },
-   {
-      "id":115,
-      "require":{
-         "level":15,
-         "quest":[
-            "Big sale"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Database - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Database_-_Part_1",
-      "exp":11500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Goshan cargo manifest",
-            "number":1,
-            "location":"Interchange",
-            "id":205
-         },
-         {
-            "type":"pickup",
-            "target":"OLI cargo manifest",
-            "number":1,
-            "location":"Interchange",
-            "id":206
-         },
-         {
-            "type":"pickup",
-            "target":"IDEA cargo manifest",
-            "number":1,
-            "location":"Interchange",
-            "id":207
-         }
-      ]
-   },
-   {
-      "id":116,
-      "require":{
-         "level":15,
-         "quest":[
-            "Database - Part 1"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Database - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Database_-_Part_2",
-      "exp":11700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Key to OLI logistics department office",
-            "number":1,
-            "location":"Interchange",
-            "id":208
-         },
-         {
-            "type":"pickup",
-            "target":"OLI cargo route documents",
-            "number":1,
-            "location":"Interchange",
-            "id":209
-         }
-      ]
-   },
-   {
-      "id":117,
-      "require":{
-         "level":25,
-         "quest":[
-            "Database - Part 2",
-            "Dressed to kill"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Gratitude",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Gratitude",
-      "exp":16300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"place",
-            "target":"Ghost balaclava",
-            "number":1,
-            "location":"Woods",
-            "id":210
-         },
-         {
-            "type":"place",
-            "target":"Shemagh",
-            "number":1,
-            "location":"Woods",
-            "id":211
-         },
-         {
-            "type":"place",
-            "target":"RayBench sunglasses",
-            "number":1,
-            "location":"Woods",
-            "id":212
-         },
-         {
-            "type":"place",
-            "target":"Round frame sunglasses",
-            "number":1,
-            "location":"Woods",
-            "id":213
-         }
-      ]
-   },
-   {
-      "id":118,
-      "require":{
-         "level":30,
-         "quest":[
-            "Gratitude"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Sales Night",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Sales_Night",
-      "exp":19800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"warning",
-            "target":"\"Survive\" Interchange 7 times (they do not have to be consecutive)",
-            "number":7,
-            "location":"Interchange",
-            "id":373
-         }
-      ]
-   },
-   {
-      "id":119,
-      "require":{
-         "level":40,
-         "quest":[
-            "Sales Night"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Supervisor",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Supervisor",
-      "exp":24100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"collect",
-            "target":"Key to Goshan cash register",
-            "number":1,
-            "location":"Any",
-            "id":214
-         }
-      ]
-   },
-   {
-      "id":120,
-      "require":{
-         "level":29,
-         "quest":[
-            "Gratitude"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Hot Delivery",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Hot_delivery",
-      "exp":25000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"place",
-            "target":"Peltor ComTac 2 headset",
-            "hint": "AVOKADO",
-            "number":2,
-            "location":"Interchange",
-            "id":215
-         },
-         {
-            "type":"place",
-            "target":"6B47 Ratnik-BSh Helmet",
-            "hint": "AVOKADO",
-            "number":2,
-            "location":"Interchange",
-            "id":216
-         },
-         {
-            "type":"place",
-            "target":"BNTI Gzhel-K armor",
-            "hint": "Front Stage",
-            "number":2,
-            "location":"Interchange",
-            "id":217
-         }
-      ]
-   },
-   {
-      "id":121,
-      "require":{
-         "level":29,
-         "quest":[
-            "Hot Delivery"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Scavenger",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Scavenger",
-      "exp":15400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.11
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Search",
-            "number":9,
-            "location":"Any",
-            "id":218
-         }
-      ]
-   },
-   {
-      "id":122,
-      "require":{
-         "level":15,
-         "quest":[
-            "Only business"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Make ULTRA Great Again",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Make_ULTRA_Great_Again",
-      "exp":9800,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":25,
-            "location":"Interchange",
-            "id":219
-         }
-      ]
-   },
-   {
-      "id":123,
-      "require":{
-         "level":24,
-         "quest":[
-            "Database - Part 2"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Minibus",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Minibus",
-      "exp":16500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Minibus 1",
-            "hint": "Safe Room",
-            "number":1,
-            "location":"Interchange",
-            "id":220
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Minibus 2",
-            "hint": "Beside Ramp",
-            "number":1,
-            "location":"Interchange",
-            "id":221
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Minibus 3",
-            "hint": "Oli Containers",
-            "number":1,
-            "location":"Interchange",
-            "id":222
-         }
-      ]
-   },
-   {
-      "id":124,
-      "require":{
-         "level":25,
-         "quest":[
-            "Database - Part 2"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Sew it good - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_1",
-      "exp":12300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Ski hat with holes for eyes 1",
-            "number":1,
-            "location":"Any",
-            "id":223
-         },
-         {
-            "type":"find",
-            "target":"Pilgrim tourist backpack",
-            "number":1,
-            "location":"Any",
-            "id":224
-         }
-      ]
-   },
-   {
-      "id":125,
-      "require":{
-         "level":25,
-         "quest":[
-            "Sew it good - Part 1"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Sew it good - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_2",
-      "exp":18700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"collect",
-            "target":"BNTI Gzhel-K armor 0-50% condition",
-            "number":1,
-            "location":"Any",
-            "id":225
-         },
-         {
-            "type":"collect",
-            "target":"BNTI Gzhel-K armor 50-100% condition",
-            "number":1,
-            "location":"Any",
-            "id":226
-         }
-      ]
-   },
-   {
-      "id":126,
-      "require":{
-         "level":25,
-         "quest":[
-            "Sew it good - Part 2"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Sew it good - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_3",
-      "exp":19700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"collect",
-            "target":"6B43 Zabralo-Sh 6A Armor 0-50% condition",
-            "number":1,
-            "location":"Any",
-            "id":227
-         },
-         {
-            "type":"collect",
-            "target":"6B43 Zabralo-Sh 6A Armor 50-100% condition",
-            "number":1,
-            "location":"Any",
-            "id":228
-         }
-      ]
-   },
-   {
-      "id":127,
-      "require":{
-         "level":25,
-         "quest":[
-            "Sew it good - Part 3"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Sew it good - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_4",
-      "exp":20700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Wartech gear rig",
-            "number":2,
-            "location":"Any",
-            "id":229
-         },
-         {
-            "type":"find",
-            "target":"BlackRock chest rig",
-            "number":2,
-            "location":"Any",
-            "id":230
-         }
-      ]
-   },
-   {
-      "id":128,
-      "require":{
-         "level":25,
-         "quest":[
-            "Sew it good - Part 4"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Charisma brings success",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Charisma_brings_success",
-      "exp":12700,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Charisma",
-            "number":10,
-            "location":"Any",
-            "id":231
-         }
-      ]
-   },
-   {
-      "id":129,
-      "require":{
-         "level":25,
-         "quest":[
-            "The key to success"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"No fuss needed",
-      "wiki":"https://escapefromtarkov.gamepedia.com/No_fuss_needed",
-      "exp":12900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"reputation",
-            "target":"Therapist",
-            "number":3,
-            "location":"Any",
-            "id":232
-         }
-      ]
-   },
-   {
-      "id":130,
-      "require":{
-         "level":23,
-         "quest":[
-            "Sew it good - Part 1"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"The Blood of War - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Blood_of_War_-_Part_2",
-      "exp":15600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Fuel conditioner",
-            "number":4,
-            "location":"Any",
-            "id":233
-         }
-      ]
-   },
-   {
-      "id":131,
-      "require":{
-         "level":30,
-         "quest":[
-            "The Blood of War - Part 2"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"The Blood of War - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_Blood_of_War_-_Part_3",
-      "exp":21000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Fuel stash 1",
-            "hint": "Outskirts side",
-            "number":1,
-            "location":"Woods",
-            "id":234
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Fuel stash 2",
-            "hint": "Sniper rock",
-            "number":1,
-            "location":"Woods",
-            "id":235
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Fuel stash 3",
-            "hint": "Jaeger camp",
-            "number":1,
-            "location":"Woods",
-            "id":236
-         }
-      ]
-   },
-   {
-      "id":132,
-      "require":{
-         "level":27,
-         "quest":[
-            "Sew it good - Part 3"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Living high is not a crime - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Living_high_is_not_a_crime_-_Part_1",
-      "exp":23000,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.09
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Bronze lion",
-            "number":2,
-            "location":"Any",
-            "id":237
-         },
-         {
-            "type":"find",
-            "target":"Horse figurine",
-            "number":2,
-            "location":"Any",
-            "id":238
-         },
-         {
-            "type":"find",
-            "target":"Cat figurine",
-            "number":1,
-            "location":"Any",
-            "id":239
-         },
-         {
-            "type":"find",
-            "target":"Roler submariner gold wrist watch",
-            "number":1,
-            "location":"Any",
-            "id":240
-         }
-      ]
-   },
-   {
-      "id":133,
-      "require":{
-         "level":27,
-         "quest":[
-            "The Blood of War - Part 3"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Living high is not a crime - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Living_high_is_not_a_crime_-_Part_2",
-      "exp":29600,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Antique teapot",
-            "number":3,
-            "location":"Any",
-            "id":241
-         },
-         {
-            "type":"find",
-            "target":"Antique vase",
-            "number":2,
-            "location":"Any",
-            "id":242
-         }
-      ]
-   },
-   {
-      "id":134,
-      "require":{
-         "level":2,
-         "quest":[
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Introduction",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Introduction",
-      "exp":4500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Jaeger's message",
-            "number":1,
-            "location":"Woods",
-            "id":243
-         }
-      ]
-   },
-   {
-      "id":135,
-      "require":{
-         "level":2,
-         "quest":[
-            "Introduction"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Acquaintance",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Acquaintance",
-      "exp":4000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Iskra lunch box",
-            "number":3,
-            "location":"Any",
-            "id":244
-         },
-         {
-            "type":"find",
-            "target":"Emelya rye croutons",
-            "number":2,
-            "location":"Any",
-            "id":245
-         },
-         {
-            "type":"find",
-            "target":"Can of delicious beef stew",
-            "number":2,
-            "location":"Any",
-            "id":246
-         }
-      ]
-   },
-   {
-      "id":136,
-      "require":{
-         "level":10,
-         "quest":[
-            "Acquaintance"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Unprotected, but dangerous",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Unprotected,_but_dangerous",
-      "exp":7000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":5,
-            "location":"Woods",
-            "with":[
-               "No body armor"
-            ],
-            "id":247
-         }
-      ]
-   },
-   {
-      "id":137,
-      "require":{
-         "level":10,
-         "quest":[
-            "Acquaintance"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Thrifty",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Thrifty",
-      "exp":6500,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"place",
-            "target":"Iskra lunch box",
-            "hint": "ZB-014",
-            "number":1,
-            "location":"Woods",
-            "id":248
-         },
-         {
-            "type":"place",
-            "target":"Bottle of water",
-            "hint": "ZB-014",
-            "number":1,
-            "location":"Woods",
-            "id":249
-         },
-         {
-            "type":"place",
-            "target":"Iskra lunch box",
-            "hint": "ZB-016",
-            "number":1,
-            "location":"Woods",
-            "id":250
-         },
-         {
-            "type":"place",
-            "target":"Bottle of water",
-            "hint": "ZB-016",
-            "number":1,
-            "location":"Woods",
-            "id":251
-         }
-      ]
-   },
-   {
-      "id":138,
-      "require":{
-         "level":10,
-         "quest":[
-            "The survivalist path - Thrifty"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Zhivchik",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Zhivchik",
-      "exp":9000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"warning",
-            "target":"Gain the dehydrated status for 5 minutes",
-            "number":1,
-            "location":"Any",
-            "id":352
-         }
-      ]
-   },
-   {
-      "id":139,
-      "require":{
-         "level":10,
-         "quest":[
-            "The survivalist path - Zhivchik"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Wounded beast",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Wounded_beast",
-      "exp":10000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":3,
-            "location":"Any",
-            "with":[
-               "Suffering from pain effect"
-            ],
-            "id":252
-         }
-      ]
-   },
-   {
-      "id":140,
-      "require":{
-         "level":10,
-         "quest":[
-            "The survivalist path - Wounded beast"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Tough guy",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Tough_guy",
-      "exp":12000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":3,
-            "location":"Woods",
-            "with":[
-               "In one raid",
-               "No healing used"
-            ],
-            "id":253
-         }
-      ]
-   },
-   {
-      "id":141,
-      "require":{
-         "level":20,
-         "quest":[
-            "The survivalist path - Tough guy"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Courtesy visit",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Courtesy_visit",
-      "exp":10000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Priest house",
-            "number":1,
-            "location":"Shoreline",
-            "id":254
-         },
-         {
-            "type":"locate",
-            "target":"Fisherman house",
-            "number":1,
-            "location":"Shoreline",
-            "id":255
-         },
-         {
-            "type":"locate",
-            "target":"Chairman house",
-            "number":1,
-            "location":"Shoreline",
-            "id":256
-         }
-      ]
-   },
-   {
-      "id":142,
-      "require":{
-         "level":28,
-         "quest":[
-            "Courtesy visit"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Nostalgia",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Nostalgia",
-      "exp":10000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Jaeger's photo album",
-            "number":1,
-            "location":"Shoreline",
-            "id":257
-         }
-      ]
-   },
-   {
-      "id":143,
-      "require":{
-         "level":17,
-         "quest":[
-            "Gunsmith - Part 5"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_1",
-      "exp":18900,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":5,
-            "location":"Any",
-            "with":[
-               "A bolt-action sniper rifle without scope",
-               "At least 40 meters away"
-            ],
-            "id":258
-         }
-      ]
-   },
-   {
-      "id":144,
-      "require":{
-         "level":17,
-         "quest":[
-            "The Tarkov shooter - Part 1"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_2",
-      "exp":19200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Any",
-            "number":3,
-            "location":"Any",
-            "with":[
-               "A bolt-action sniper rifle",
-               "Leg shots",
-               "At least 40 meters away"
-            ],
-            "id":259
-         },
-         {
-            "type":"kill",
-            "target":"Any",
-            "number":2,
-            "location":"Any",
-            "with":[
-               "A bolt-action sniper rifle",
-               "head shots",
-               "At least 40 meters away"
-            ],
-            "id":260
-         }
-      ]
-   },
-   {
-      "id":145,
-      "require":{
-         "level":17,
-         "quest":[
-            "The Tarkov shooter - Part 2"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_3",
-      "exp":16200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":3,
-            "location":"Any",
-            "with":[
-               "A bolt-action sniper rifle",
-               "Less than 25 meters away"
-            ],
-            "id":261
-         }
-      ]
-   },
-   {
-      "id":146,
-      "require":{
-         "level":17,
-         "quest":[
-            "The Tarkov shooter - Part 3"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 4",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_4",
-      "exp":16400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Sniper Rifles",
-            "number":3,
-            "location":"Any",
-            "id":262
-         }
-      ]
-   },
-   {
-      "id":147,
-      "require":{
-         "level":17,
-         "quest":[
-            "The Tarkov shooter - Part 4"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 5",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_5",
-      "exp":20000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":8,
-            "location":"Customs",
-            "with":[
-               "A bolt-action sniper rifle",
-               "Between 21 and 05 hours"
-            ],
-            "id":263
-         }
-      ]
-   },
-   {
-      "id":148,
-      "require":{
-         "level":17,
-         "quest":[
-            "The Tarkov shooter - Part 5"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 6",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_6",
-      "exp":20300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":5,
-            "location":"Any",
-            "with":[
-               "A bolt-action sniper rifle",
-               "Must be sniper scavs"
-            ],
-            "id":264
-         }
-      ]
-   },
-   {
-      "id":149,
-      "require":{
-         "level":17,
-         "quest":[
-            "The Tarkov shooter - Part 6"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 7",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_7",
-      "exp":20700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":5,
-            "location":"Any",
-            "with":[
-               "Supressed bolt-action sniper rifle",
-               "At least 45 meters away"
-            ],
-            "id":265
-         }
-      ]
-   },
-   {
-      "id":150,
-      "require":{
-         "level":17,
-         "quest":[
-            "The Tarkov shooter - Part 7"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The Tarkov shooter - Part 8",
-      "wiki":"https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_8",
-      "exp":25200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":3,
-            "location":"Woods",
-            "with":[
-               "A bolt-action sniper rifle",
-               "In a single raid"
-            ],
-            "id":266
-         }
-      ]
-   },
-   {
-      "id":151,
-      "require":{
-         "level":17,
-         "quest":[
-            "The survivalist path - Wounded beast"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Cold blooded",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Cold_blooded",
-      "exp":11000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":2,
-            "location":"Any",
-            "with":[
-               "Headshot",
-               "While you have tremor effect"
-            ],
-            "id":267
-         }
-      ]
-   },
-   {
-      "id":152,
-      "require":{
-         "level":10,
-         "quest":[
-            "Colleagues - Part 1"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Colleagues - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Colleagues_-_Part_2",
-      "exp":13200,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Cottage back entrance key",
-            "number":1,
-            "location":"Shoreline",
-            "id":321
-         },
-         {
-            "type":"pickup",
-            "target":"Sanitar's surgery kit",
-            "number":1,
-            "location":"Shoreline",
-            "id":318
-         },
-         {
-            "type":"pickup",
-            "target":"Sanitar's ophthalmoscope",
-            "number":1,
-            "location":"Shoreline",
-            "id":319
-         }
-      ]
-   },
-   {
-      "id":153,
-      "require":{
-         "level":10,
-         "quest":[
-            "Colleagues - Part 2",
-            "Rigged game",
-            "The chemistry closet"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Colleagues - Part 3",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Colleagues_-_Part_3",
-      "exp":13200,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"warning",
-            "target":"Do not kill Sanitar",
-            "number":1,
-            "location":"Shoreline",
-            "id":320
-         },
-         {
-            "type":"find",
-            "target":"AHF1-M",
-            "number":1,
-            "location":"Any",
-            "id":322
-         },
-         {
-            "type":"find",
-            "target":"3-(b-TG)",
-            "number":1,
-            "location":"Any",
-            "id":323
-         },
-         {
-            "type":"collect",
-            "target":"Blue keycard",
-            "number":1,
-            "location":"Any",
-            "id":324
-         },
-         {
-            "type":"collect",
-            "target":"Green keycard",
-            "number":1,
-            "location":"Any",
-            "id":325
-         }
-      ],
-      "alternative":[
-         "Huntsman path - Sadist"
-      ]
-   },
-   {
-      "id":154,
-      "require":{
-         "level":17,
-         "quest":[
-            "The survivalist path - Cold blooded"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Combat medic",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Combat_medic",
-      "exp":14000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"skill",
-            "target":"Vitality",
-            "number":5,
-            "location":"Any",
-            "id":270
-         }
-      ]
-   },
-   {
-      "id":155,
-      "require":{
-         "level":25,
-         "quest":[
-            "The survivalist path - Cold blooded"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Ambulance",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Ambulance",
-      "exp":12000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"CMS surgery kit",
-            "number":2,
-            "location":"Any",
-            "id":271
-         },
-         {
-            "type":"find",
-            "target":"Portable defibrillator",
-            "number":1,
-            "location":"Any",
-            "id":272
-         }
-      ]
-   },
-   {
-      "id":156,
-      "require":{
-         "level":17,
-         "quest":[
-            "The survivalist path - Wounded beast"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Secured perimeter",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Secured_perimeter",
-      "exp":14000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":6,
-            "location":"Factory",
-            "with":[
-               "In the office area"
-            ],
-            "id":273
-         }
-      ]
-   },
-   {
-      "id":157,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Secured perimeter"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Reserv",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Reserv",
-      "exp":9000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Food storage",
-            "number":1,
-            "location":"Reserve",
-            "id":274
-         }
-      ]
-   },
-   {
-      "id":158,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Secured perimeter"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Woods cleaning",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Woods_cleaning",
-      "exp":18000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":30,
-            "location":"Any",
-            "id":275
-         }
-      ]
-   },
-   {
-      "id":159,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Woods cleaning"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Controller",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Controller",
-      "exp":21000,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":2,
-            "location":"Any",
-            "with":[
-               "While they are flashed"
-            ],
-            "id":276
-         }
-      ]
-   },
-   {
-      "id":160,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Woods cleaning"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Evil watchman",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Evil_watchman",
-      "exp":21000,
-      "nokappa": true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":5,
-            "location":"Customs",
-            "with":[
-               "In the dorms area"
-            ],
-            "id":277
-         }
-      ]
-   },
-   {
-      "id":161,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Woods cleaning"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Fishing place",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Fishing_place",
-      "exp":15000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"TerraGroup Labs access keycard",
-            "number":2,
-            "location":"Any",
-            "id":278
-         }
-      ]
-   },
-   {
-      "id":162,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Secured perimeter"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - The trophy",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_The_trophy",
-      "exp":20000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Reshala",
-            "number":1,
-            "location":"Customs",
-            "id":279
-         },
-         {
-            "type":"find",
-            "target":"golden TT",
-            "number":1,
-            "location":"Customs",
-            "id":280
-         }
-      ]
-   },
-   {
-      "id":163,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - The trophy"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Justice",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Justice",
-      "exp":20000,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":3,
-            "location":"Customs",
-            "with":[
-               "Reshala bodyguards"
-            ],
-            "id":281
-         }
-      ]
-   },
-   {
-      "id":164,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - The trophy"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Sell-out",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Sell-out",
-      "exp":23000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Killa",
-            "number":1,
-            "location":"Interchange",
-            "id":282
-         },
-         {
-            "type":"find",
-            "target":"Killa's helmet",
-            "number":1,
-            "location":"Interchange",
-            "id":283
-         }
-      ]
-   },
-   {
-      "id":165,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Sell-out"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Woods keeper",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Woods_keeper",
-      "exp":25000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Shturman",
-            "number":1,
-            "location":"Woods",
-            "id":284
-         },
-         {
-            "type":"find",
-            "target":"Shturman's key",
-            "number":1,
-            "location":"Woods",
-            "id":285
-         }
-      ]
-   },
-   {
-      "id":166,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Woods keeper"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Eraser - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Eraser_-_Part_1",
-      "exp":30000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Glukhar",
-            "number":1,
-            "location":"Reserve",
-            "id":286
-         }
-      ]
-   },
-   {
-      "id":167,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Eraser - Part 1"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Eraser - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Eraser_-_Part_2",
-      "exp":30000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":6,
-            "location":"Any",
-            "with":[
-               "Raider scavs"
-            ],
-            "id":287
-         }
-      ]
-   },
-   {
-      "id":168,
-      "require":{
-         "level":17,
-         "quest":[
-            "Huntsman path - Woods keeper"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Hunting trip",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Hunting_trip",
-      "exp":16000,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Shturman",
-            "number":1,
-            "location":"Woods",
-            "with":[
-               "Remington M700",
-               "March Tactical 3-24x42 FPP scope"
-            ],
-            "id":269
-         }
-      ]
-   },
-   {
-      "id":169,
-      "require":{
-         "level":6,
-         "quest":[
-            "Shortage"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Operation Aquarius - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Operation_Aquarius_-_Part_1",
-      "exp":3400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         },
-         {
-            "trader":"Skier",
-            "rep":-0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Dorm room 206 Key",
-            "number":1,
-            "location":"Customs",
-            "id":289
-         },
-         {
-            "type":"locate",
-            "target":"The hidden water in 2-story dorms, room 206",
-            "number":1,
-            "location":"Customs",
-            "id":290
-         }
-      ]
-   },
-   {
-      "id":170,
-      "require":{
-         "level":6,
-         "quest":[
-            "Operation Aquarius - Part 1"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Operation Aquarius - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Operation_Aquarius_-_Part_2",
-      "exp":3400,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.09
-         },
-         {
-            "trader":"Skier",
-            "rep":-0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":15,
-            "location":"Customs",
-            "id":291
-         }
-      ]
-   },
-   {
-      "id":171,
-      "require":{
-         "level":10,
-         "quest":[
-            "Golden swag"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Polikhim hobo",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Polikhim_hobo",
-      "exp":7000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":25,
-            "location":"Customs",
-            "id":292
-         }
-      ]
-   },
-   {
-      "id":172,
-      "require":{
-         "level":25,
-         "quest":[
-            "Polikhim hobo"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Regulated materials",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Regulated_materials",
-      "exp":0,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Military battery",
-            "number":1,
-            "location":"Any",
-            "id":293
-         },
-         {
-            "type":"find",
-            "target":"30-mil. shells for BMP cannon",
-            "number":5,
-            "location":"Any",
-            "id":294
-         }
-      ]
-   },
-   {
-      "id":173,
-      "require":{
-         "level":8,
-         "quest":[
-            "The Extortionist"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Stirrup",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Stirrup",
-      "exp":4700,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.12
-         },
-         {
-            "trader":"Prapor",
-            "rep":-0.12
-         },
-         {
-            "trader":"Therapist",
-            "rep":-0.05
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"PMCs",
-            "number":3,
-            "location":"Any",
-            "with":[
-               "pistol"
-            ],
-            "id":295
-         }
-      ]
-   },
-   {
-      "id":174,
-      "require":{
-         "level":14,
-         "quest":[
-            "Wet Job - Part 4"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Mentor",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Mentor",
-      "exp":4700,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"collect",
-            "target":"Euros",
-            "number":50000,
-            "location":"Any",
-            "id":296
-         }
-      ]
-   },
-   {
-      "id":175,
-      "require":{
-         "level":12,
-         "quest":[
-            "Farming - Part 2"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"Bad habit",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Bad_habit",
-      "exp":9000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Malboro cigarettes",
-            "number":5,
-            "location":"Any",
-            "id":297
-         },
-         {
-            "type":"find",
-            "target":"Strike cigarettes",
-            "number":5,
-            "location":"Any",
-            "id":298
-         },
-         {
-            "type":"find",
-            "target":"Wilston cigarettes",
-            "number":5,
-            "location":"Any",
-            "id":299
-         }
-      ]
-   },
-   {
-      "id":176,
-      "require":{
-         "level":26,
-         "quest":[
-            "Sew it good - Part 2"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"The key to success",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_key_to_success",
-      "exp":18100,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Ragman",
-            "rep":0.07
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Clothes design handbook Part 1",
-            "hint": "Oli side 2F",
-            "number":1,
-            "location":"Interchange",
-            "id":300
-         },
-         {
-            "type":"pickup",
-            "target":"Clothes design handbook Part 2",
-            "hint": "Idea side 1F",
-            "number":1,
-            "location":"Interchange",
-            "id":301
-         }
-      ]
-   },
-   {
-      "id":177,
-      "require":{
-         "level":20,
-         "quest":[
-            "What's on the flash drive?"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Shady Business",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Shady_business",
-      "exp":11000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Secure Flash drive",
-            "number":3,
-            "location":"Any",
-            "id":302
-         }
-      ]
-   },
-   {
-      "id":178,
-      "require":{
-         "level":10,
-         "quest":[
-            "Ice cream cones"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Postman Pat - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Postman_Pat_-_Part_2",
-      "exp":4200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.06
-         }
-      ],
-      "objectives":[
-         {
-            "type":"pickup",
-            "target":"Sealed letter",
-            "number":1,
-            "location":"Factory",
-            "id":13
-         }
-      ]
-   },
-   {
-      "id":179,
-      "require":{
-         "level":11,
-         "quest":[
-            "Chemical - Part 3"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Out of curiosity",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Out_of_curiosity",
-      "exp":8300,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":-0.3
-         },
-         {
-            "trader":"Therapist",
-            "rep":0.3
-         },
-         {
-            "trader":"Prapor",
-            "rep":-0.15
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Transport van",
-            "number":1,
-            "location":"Customs",
-            "id":77
-         }
-      ],
-      "alternative":[
-         "Chemical - Part 4",
-         "Big customer"
-      ]
-   },
-   {
-      "id":180,
-      "require":{
-         "level":11,
-         "quest":[
-            "Chemical - Part 3"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Big customer",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Big_customer",
-      "exp":8200,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":-0.3
-         },
-         {
-            "trader":"Therapist",
-            "rep":-0.3
-         },
-         {
-            "trader":"Prapor",
-            "rep":0.1
-         },
-         {
-            "trader":"Jaeger",
-            "rep":-0.01
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Transport van",
-            "number":1,
-            "location":"Customs",
-            "id":77
-         }
-      ],
-      "alternative":[
-         "Chemical - Part 4",
-         "Out of curiosity"
-      ]
-   },
-   {
-      "id":181,
-      "require":{
-         "quest":[
-            "The survivalist path - Cold blooded"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"The survivalist path - Junkie",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Junkie",
-      "exp":12000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":15,
-            "location":"Woods",
-            "with":[
-               "Stimulants active"
-            ],
-            "id":305
-         }
-      ]
-   },
-   {
-      "id":182,
-      "require":{
-         "level":40,
-         "quest":[
-            "Sew it good - Part 4"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Textile - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Textile_-_Part_1",
-      "exp":0,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Aramid fiber cloth",
-            "number":5,
-            "location":"Any",
-            "id":306
-         },
-         {
-            "type":"find",
-            "target":"Ripstop cloth",
-            "number":10,
-            "location":"Any",
-            "id":307
-         },
-         {
-            "type":"find",
-            "target":"Paracord",
-            "number":3,
-            "location":"Any",
-            "id":308
-         }
-      ]
-   },
-   {
-      "id":183,
-      "require":{
-         "level":47,
-         "quest":[
-            "Textile - Part 1"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"Textile - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Textile_-_Part_2",
-      "exp":0,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Fleece cloth",
-            "number":10,
-            "location":"Any",
-            "id":309
-         },
-         {
-            "type":"find",
-            "target":"Polyamide fabric Cordura",
-            "number":10,
-            "location":"Any",
-            "id":310
-         },
-         {
-            "type":"find",
-            "target":"KEKTAPE duct tape",
-            "number":5,
-            "location":"Any",
-            "id":311
-         }
-      ]
-   },
-   {
-      "id":184,
-      "require":{
-         "level":21,
-         "quest":[
-            "Shaking up teller"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Anesthesia",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Anesthesia",
-      "exp":12600,
-      "nokappa":true,
-      "unlocks":[
-         {
-            "trader":"Prapor",
-            "rep":0.1
-         }
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Trading post 1",
-            "hint":"Cottages",
-            "number":1,
-            "location":"Shoreline",
-            "id":312
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Trading post 2",
-            "hint":"Pier",
-            "number":1,
-            "location":"Shoreline",
-            "id":313
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Trading post 3",
-            "hint":"Resort",
-            "number":1,
-            "location":"Shoreline",
-            "id":314
-         }
-      ]
-   },
-   {
-      "id":185,
-      "require":{
-         "level":10,
-         "quest":[
-            "General wares"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"Colleagues - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Colleagues_-_Part_1",
-      "exp":12600,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Therapist",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Health resort group",
-            "number":1,
-            "location":"Shoreline",
-            "id":315
-         },
-         {
-            "type":"locate",
-            "target":"Pier group",
-            "number":1,
-            "location":"Shoreline",
-            "id":316
-         },
-         {
-            "type":"locate",
-            "target":"Cottage group",
-            "number":1,
-            "location":"Shoreline",
-            "id":317
-         }
-      ]
-   },
-   {
-      "id":186,
-      "require":{
-         "level":21,
-         "quest":[
-            "Anesthesia"
-         ]
-      },
-      "giver":"Skier",
-      "turnin":"Skier",
-      "title":"Rigged game",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Rigged_game",
-      "exp":13200,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Skier",
-            "rep":0.1
-         }
-      ],
-      "objectives":[
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Health resort Medical container",
-            "number":1,
-            "location":"Shoreline",
-            "id":326
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Cottages Medical container",
-            "number":1,
-            "location":"Shoreline",
-            "id":327
-         },
-         {
-            "type":"mark",
-            "tool":"MS2000 marker",
-            "target":"Pier Medical container",
-            "number":1,
-            "location":"Shoreline",
-            "id":328
-         }
-      ]
-   },
-   {
-      "id":187,
-      "require":{
-         "level":21,
-         "quest":[
-            "Anesthesia",
-            "Colleagues - Part 1"
-         ]
-      },
-      "giver":"Mechanic",
-      "turnin":"Mechanic",
-      "title":"The chemistry closet",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_chemistry_closet",
-      "exp":13800,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Mechanic",
-            "rep":0.14
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Key with tape",
-            "number":1,
-            "location":"Shoreline",
-            "id":329
-         },
-         {
-            "type":"locate",
-            "target":"Sanitar's office",
-            "number":1,
-            "location":"Shoreline",
-            "id":330
-         }
-      ]
-   },
-   {
-      "id":188,
-      "require":{
-         "level":21,
-         "quest":[
-            "Anesthesia",
-            "Colleagues - Part 1"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"Samples",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Samples",
-      "exp":13200,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.12
-         }
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"M.U.L.E. stimulator",
-            "number":1,
-            "location":"Any",
-            "id":331
-         },
-         {
-            "type":"find",
-            "target":"Cocktail \"Obdolbos\"",
-            "number":1,
-            "location":"Any",
-            "id":332
-         },
-         {
-            "type":"find",
-            "target":"Meldonin",
-            "number":1,
-            "location":"Any",
-            "id":333
-         },
-         {
-            "type":"find",
-            "target":"AHF1-M",
-            "number":1,
-            "location":"Any",
-            "id":334
-         },
-         {
-            "type":"find",
-            "target":"P22",
-            "number":1,
-            "location":"Any",
-            "id":335
-         },
-         {
-            "type":"find",
-            "target":"L1 (Norepinephrine)",
-            "number":1,
-            "location":"Any",
-            "id":336
-         },
-         {
-            "type":"find",
-            "target":"3-(b-TG)",
-            "number":1,
-            "location":"Any",
-            "id":337
-         }
-      ]
-   },
-   {
-      "id":189,
-      "require":{
-         "level":21,
-         "quest":[
-            "Samples",
-            "Huntsman path - Sadist"
-         ]
-      },
-      "giver":"Peacekeeper",
-      "turnin":"Peacekeeper",
-      "title":"TerraGroup employee",
-      "wiki":"https://escapefromtarkov.gamepedia.com/TerraGroup_employee",
-      "exp":14400,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Peacekeeper",
-            "rep":0.2
-         }
-      ],
-      "objectives":[
-         {
-            "type":"key",
-            "target":"Key card with a blue marking",
-            "number":1,
-            "location":"Labs",
-            "id":338
-         },
-         {
-            "type":"locate",
-            "target":"Sanitar's workplace",
-            "number":1,
-            "location":"Labs",
-            "id":339
-         },
-         {
-            "type":"pickup",
-            "target":"Marked with tape flash drive",
-            "number":1,
-            "location":"Labs",
-            "id":340
-         }
-      ]
-   },
-   {
-      "id":190,
-      "require":{
-         "level":21,
-         "quest":[
-            "Colleagues - Part 2",
-            "Rigged game",
-            "The chemistry closet"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Huntsman path - Sadist",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Sadist",
-      "exp":13800,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.2
-         },
-         {
-            "trader":"Therapist",
-            "rep":-0.2
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Sanitar",
-            "number":1,
-            "location":"Shoreline",
-            "id":341
-         }
-      ],
-      "alternative":[
-         "Colleagues - Part 3"
-      ]
-   },
-   {
-      "id":191,
-      "require":{
-         "level":10,
-         "quest":[
-            "BP depot"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The bunker - Part 1",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_bunker_-_Part_1",
-      "exp":6000,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Underground bunker",
-            "number":1,
-            "location":"Reserve",
-            "id":342
-         },
-         {
-            "type":"locate",
-            "target":"Bunker control room",
-            "number":1,
-            "location":"Reserve",
-            "id":343
-         }
-      ]
-   },
-   {
-      "id":192,
-      "require":{
-         "level":10,
-         "quest":[
-            "The bunker - Part 1"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"The bunker - Part 2",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_bunker_-_Part_2",
-      "exp":6600,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.08
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"White Bishop hermetic door",
-            "number":1,
-            "location":"Reserve",
-            "id":344
-         },
-         {
-            "type":"locate",
-            "target":"Black Bishop hermetic door",
-            "number":1,
-            "location":"Reserve",
-            "id":345
-         },
-         {
-            "type":"locate",
-            "target":"Black Pawn hermetic door",
-            "number":1,
-            "location":"Reserve",
-            "id":346
-         },
-         {
-            "type":"locate",
-            "target":"White Pawn hermetic door",
-            "number":1,
-            "location":"Reserve",
-            "id":347
-         },
-         {
-            "type":"locate",
-            "target":"White King hermetic door",
-            "number":1,
-            "location":"Reserve",
-            "id":348
-         }
-      ]
-   },
-   {
-      "id":193,
-      "require":{
-         "level":5,
-         "quest":[
-            "Debut"
-         ]
-      },
-      "giver":"Prapor",
-      "turnin":"Prapor",
-      "title":"Search mission",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Search_mission",
-      "exp":2000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Prapor",
-            "rep":0.04
-         }
-      ],
-      "objectives":[
-         {
-            "type":"locate",
-            "target":"Missing convoy",
-            "number":1,
-            "location":"Woods",
-            "id":349
-         },
-         {
-            "type":"locate",
-            "target":"Temporary USEC camp",
-            "number":1,
-            "location":"Woods",
-            "id":350
-         }
-      ]
-   },
-   {
-      "id":194,
-      "require":{
-         "level":26,
-         "quest":[
-            "The key to success"
-         ]
-      },
-      "giver":"Ragman",
-      "turnin":"Ragman",
-      "title":"The stylish one",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_stylish_one",
-      "exp":0,
-      "nokappa":true,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Killa",
-            "number":100,
-            "location":"Interchange",
-            "id":351
-         }
-      ]
-   },
-   {
-      "id":196,
-      "require":{
-         "quest":[
-            "The survivalist path - Cold blooded"
-         ]
-      },
-      "giver":"Jaeger",
-      "turnin":"Jaeger",
-      "title":"Thee survivalist path - Eagle-owl",
-      "wiki":"https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Eagle-owl",
-      "exp":13000,
-      "unlocks":[
-
-      ],
-      "reputation":[
-         {
-            "trader":"Jaeger",
-            "rep":0.03
-         }
-      ],
-      "objectives":[
-         {
-            "type":"kill",
-            "target":"Scavs",
-            "number":6,
-            "location":"Any",
-            "with":[
-               "No NVG or Thermals",
-               "Between 21 and 04 hours"
-            ],
-            "id":288
-         }
-      ]
-   },
-   {
-      "id":195,
-      "require":{
-         "level":40,
-         "quest":[
-           "Shootout picnic",
-           "Perfect mediator",
-           "Insomnia",
-           "Test drive",
-           "The Punisher - Part 6",
-           "Supply plans",
-           "Kind of sabotage",
-           "General wares",
-           "Car repair",
-           "Decontamination Service",
-           "Athlete",
-           "Chemical - Part 4",
-           "\"Vitamins\" - Part 2",
-           "Lend lease - Part 2",
-           "Silent caliber",
-           "Flint",
-           "Setup",
-           "The Cult - Part 2",
-           "Cargo X - Part 3",
-           "Psycho Sniper",
-           "The guide",
-           "Gunsmith - Part 16",
-           "Signal - Part 4",
-           "Scout",
-           "Insider",
-           "Fertilizers",
-           "A Shooter Born in Heaven",
-           "Supervisor",
-           "Scavenger",
-           "Make ULTRA Great Again",
-           "Minibus",
-           "Sew it good - Part 4",
-           "No fuss needed",
-           "Living high is not a crime - Part 2",
-           "The survivalist path - Unprotected, but dangerous",
-           "Nostalgia",
-           "The Tarkov shooter - Part 8",
-           "The survivalist path - Combat medic",
-           "Ambulance",
-           "Reserv",
-           "Fishing place",
-           "Huntsman path - Eraser - Part 2",
-           "Operation Aquarius - Part 2",
-           "Polikhim hobo",
-           "Stirrup",
-           "Bad habit",
-           "Shady Business",
-           "Postman Pat - Part 2",
-           "Out of curiosity",
-           "Big customer",
-           "The survivalist path - Junkie",
-           "Search mission",
-           "Thee survivalist path - Eagle-owl",
-           "An apple a day - keeps the doctor away"
-         ]
-      },
-      "giver":"Fence",
-      "turnin":"Fence",
-      "title":"Collector",
-      "wiki":"https://escapefromtarkov.gamepedia.com/Collector",
-      "exp":0,
-      "unlocks":[
-
-      ],
-      "reputation":[
-
-      ],
-      "objectives":[
-         {
-            "type":"find",
-            "target":"Old firesteel",
-            "number":1,
-            "location":"Any",
-            "id":353
-         },
-         {
-            "type":"find",
-            "target":"Antique axe",
-            "number":1,
-            "location":"Any",
-            "id":354
-         },
-         {
-            "type":"find",
-            "target":"Battered antique Book",
-            "number":1,
-            "location":"Any",
-            "id":355
-         },
-         {
-            "type":"find",
-            "target":"FireKlean gun lube",
-            "number":1,
-            "location":"Any",
-            "id":356
-         },
-         {
-            "type":"find",
-            "target":"Golden rooster",
-            "number":1,
-            "location":"Any",
-            "id":357
-         },
-         {
-            "type":"find",
-            "target":"Silver Badge",
-            "number":1,
-            "location":"Any",
-            "id":358
-         },
-         {
-            "type":"find",
-            "target":"Deadlyslob's beard oil",
-            "number":1,
-            "location":"Any",
-            "id":359
-         },
-         {
-            "type":"find",
-            "target":"Golden 1GPhone",
-            "number":1,
-            "location":"Any",
-            "id":360
-         },
-         {
-            "type":"find",
-            "target":"Jar of DevilDog mayo",
-            "number":1,
-            "location":"Any",
-            "id":361
-         },
-         {
-            "type":"find",
-            "target":"Can of sprats",
-            "number":1,
-            "location":"Any",
-            "id":362
-         },
-         {
-            "type":"find",
-            "target":"Fake mustache",
-            "number":1,
-            "location":"Any",
-            "id":363
-         },
-         {
-            "type":"find",
-            "target":"Kotton beanie",
-            "number":1,
-            "location":"Any",
-            "id":364
-         },
-         {
-            "type":"find",
-            "target":"Can of Dr. Lupo's coffee beans",
-            "number":1,
-            "location":"Any",
-            "id":365
-         },
-         {
-            "type":"find",
-            "target":"Pestily plague mask",
-            "number":1,
-            "location":"Any",
-            "id":366
-         },
-         {
-            "type":"find",
-            "target":"Raven figurine",
-            "number":1,
-            "location":"Any",
-            "id":367
-         },
-         {
-            "type":"find",
-            "target":"Shroud half-mask",
-            "number":1,
-            "location":"Any",
-            "id":368
-         },
-         {
-            "type":"find",
-            "target":"Veritas guitar pick",
-            "number":1,
-            "location":"Any",
-            "id":369
-         },
-         {
-            "type":"find",
-            "target":"42nd Signature Blend English Tea",
-            "number":1,
-            "location":"Any",
-            "id":370
-         }
-      ]
-   },
-   {
-      "id":197,
-      "require":{
-         "quest":[
-            "Health Care Privacy - Part 3"
-         ]
-      },
-      "giver":"Therapist",
-      "turnin":"Therapist",
-      "title":"An apple a day - keeps the doctor away",
-      "wiki":"https://escapefromtarkov.gamepedia.com/An_apple_a_day_-_keeps_the_doctor_away",
-      "exp":0,
-      "unlocks":[
-      ],
-      "reputation":[
-      ],
-      "objectives":[
-         {
-            "type":"collect",
-            "target":"Rubles",
-            "number":400000,
-            "location":"Any",
-            "id":372
-         }
-      ]
-   }
+            "loyalty": "Prapor2"
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Shaking up teller",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Shaking_up_teller",
+        "exp": 6100,
+        "unlocks": [
+            "PBS-4 5.45x39 Silencer",
+            "Hexagon 12K sound suppressor"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Dorm room 203 Key",
+                "number": 1,
+                "location": "Customs",
+                "id": 14
+            },
+            {
+                "type": "pickup",
+                "target": "Bank case",
+                "number": 1,
+                "location": "Customs",
+                "id": 15
+            }
+        ]
+    },
+    {
+        "id": 9,
+        "require": {
+            "level": 35,
+            "quests": [
+                8
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Perfect mediator",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Perfect_mediator",
+        "exp": 17200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "reputation",
+                "target": "Prapor",
+                "number": 4,
+                "location": "Any",
+                "id": 16
+            },
+            {
+                "type": "reputation",
+                "target": "Therapist",
+                "number": 4,
+                "location": "Any",
+                "id": 17
+            },
+            {
+                "type": "reputation",
+                "target": "Skier",
+                "number": 4,
+                "location": "Any",
+                "id": 18
+            },
+            {
+                "type": "reputation",
+                "target": "Peacekeeper",
+                "number": 4,
+                "location": "Any",
+                "id": 19
+            },
+            {
+                "type": "reputation",
+                "target": "Mechanic",
+                "number": 4,
+                "location": "Any",
+                "id": 20
+            },
+            {
+                "type": "reputation",
+                "target": "Ragman",
+                "number": 4,
+                "location": "Any",
+                "id": 21
+            }
+        ]
+    },
+    {
+        "id": 10,
+        "require": {
+            "level": 30,
+            "quests": [
+                8
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Grenadier",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Grenadier",
+        "exp": 21300,
+        "unlocks": [
+            "8 pcs pack of 9x39 7N12 BP ammo"
+        ],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 12,
+                "location": "Any",
+                "with": [
+                    "Grenade"
+                ],
+                "id": 22
+            }
+        ]
+    },
+    {
+        "id": 11,
+        "require": {
+            "level": 30,
+            "quests": [
+                10
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Insomnia",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Insomnia",
+        "exp": 18500,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 30,
+                "location": "Any",
+                "with": [
+                    "Nighttime (22 - 05 hours)"
+                ],
+                "id": 23
+            }
+        ]
+    },
+    {
+        "id": 12,
+        "require": {
+            "level": 30,
+            "quests": [
+                10
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Test drive",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Test_drive_-_Part_1",
+        "exp": 31000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 5,
+                "location": "Any",
+                "with": [
+                    "M1A",
+                    "Hybrid 46 silencer",
+                    "Trijicon REAP-IR thermal scope"
+                ],
+                "id": 24
+            }
+        ]
+    },
+    {
+        "id": 13,
+        "require": {
+            "level": 17,
+            "quests": [
+                8
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The Punisher - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_1",
+        "exp": 10800,
+        "unlocks": [
+            "SV-98 bolt-action sniper rifle"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 15,
+                "location": "Shoreline",
+                "with": [
+                    "AKM"
+                ],
+                "id": 25
+            }
+        ]
+    },
+    {
+        "id": 14,
+        "require": {
+            "level": 18,
+            "quests": [
+                13
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The Punisher - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_2",
+        "exp": 13900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 12,
+                "location": "Shoreline",
+                "with": [
+                    "Supressed weapon"
+                ],
+                "id": 26
+            },
+            {
+                "type": "find",
+                "target": "Lower half-masks",
+                "number": 7,
+                "location": "Any",
+                "id": 27
+            }
+        ]
+    },
+    {
+        "id": 15,
+        "require": {
+            "level": 19,
+            "quests": [
+                14
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The Punisher - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_3",
+        "exp": 12400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            },
+            {
+                "trader": "Skier",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 25,
+                "location": "Customs",
+                "with": [
+                    "AKS-74U"
+                ],
+                "id": 28
+            }
+        ]
+    },
+    {
+        "id": 16,
+        "require": {
+            "level": 20,
+            "quests": [
+                15
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The Punisher - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_4",
+        "exp": 19000,
+        "unlocks": [
+            "5.45x39 mm BT"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.12
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 10,
+                "location": "Woods",
+                "with": [
+                    "12 gauge shotgun"
+                ],
+                "id": 29
+            },
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 10,
+                "location": "Shoreline",
+                "with": [
+                    "balaclava",
+                    "scav vest"
+                ],
+                "id": 30
+            },
+            {
+                "type": "find",
+                "target": "Bars A-2607",
+                "number": 5,
+                "location": "Any",
+                "id": 31
+            }
+        ]
+    },
+    {
+        "id": 17,
+        "require": {
+            "level": 20,
+            "quests": [
+                16
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The Punisher - Part 5",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_5",
+        "exp": 19300,
+        "unlocks": [
+            "7.62x39 mm BP"
+        ],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 10,
+                "location": "Any",
+                "with": [
+                    "PACA vest",
+                    "6b47 helmet"
+                ],
+                "id": 32
+            },
+            {
+                "type": "find",
+                "target": "AK-74N",
+                "number": 1,
+                "location": "Any",
+                "id": 33
+            },
+            {
+                "type": "find",
+                "target": "M4A1",
+                "number": 1,
+                "location": "Any",
+                "id": 34
+            },
+            {
+                "type": "find",
+                "target": "PM pistol",
+                "number": 2,
+                "location": "Any",
+                "id": 35
+            }
+        ]
+    },
+    {
+        "id": 18,
+        "require": {
+            "level": 21,
+            "quests": [
+                17
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The Punisher - Part 6",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_6",
+        "exp": 20600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.12
+            },
+            {
+                "trader": "Skier",
+                "rep": 0.06
+            },
+            {
+                "trader": "Therapist",
+                "rep": 0.15
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 15,
+                "location": "Any",
+                "with": [
+                    "SVDS 7.62x54 Sniper rifle"
+                ],
+                "id": 36
+            },
+            {
+                "type": "collect",
+                "target": "USEC dogtags",
+                "number": 7,
+                "location": "Any",
+                "id": 37
+            },
+            {
+                "type": "collect",
+                "target": "BEAR dogtags",
+                "number": 7,
+                "location": "Any",
+                "id": 38
+            }
+        ]
+    },
+    {
+        "id": 19,
+        "require": {
+            "level": 1,
+            "quests": []
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Shortage",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Shortage",
+        "exp": 500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Salewa First Aid Kit",
+                "number": 3,
+                "location": "Any",
+                "id": 39
+            }
+        ]
+    },
+    {
+        "id": 20,
+        "require": {
+            "level": 4,
+            "quests": [
+                19
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Sanitary Standards - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Sanitary_Standards_-_Part_1",
+        "exp": 2200,
+        "unlocks": [
+            "Car first aid kit"
+        ],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Gas analyzer",
+                "number": 1,
+                "location": "Any",
+                "id": 40
+            }
+        ]
+    },
+    {
+        "id": 21,
+        "require": {
+            "level": 8,
+            "quests": [
+                20
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Sanitary Standards - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Sanitary_Standards_-_Part_2",
+        "exp": 4500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Gas analyzer",
+                "number": 2,
+                "location": "Any",
+                "id": 41
+            }
+        ]
+    },
+    {
+        "id": 22,
+        "require": {
+            "level": 8,
+            "quests": [
+                21
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Painkiller",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Painkiller",
+        "exp": 4600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Morphine injector",
+                "number": 4,
+                "location": "Any",
+                "have": 0,
+                "id": 42
+            }
+        ]
+    },
+    {
+        "id": 23,
+        "require": {
+            "level": 10,
+            "quests": [
+                22
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Pharmacist",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Pharmacist",
+        "exp": 5900,
+        "unlocks": [
+            "6B47 Helmet with cover (flora digital)"
+        ],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Dorm room 114 Key",
+                "number": 1,
+                "location": "Customs",
+                "id": 43
+            },
+            {
+                "type": "pickup",
+                "target": "Carbon case",
+                "number": 1,
+                "location": "Customs",
+                "id": 44
+            }
+        ]
+    },
+    {
+        "id": 24,
+        "require": {
+            "level": 13,
+            "quests": [
+                23
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Supply plans",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Supply_plans",
+        "exp": 7700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            },
+            {
+                "trader": "Skier",
+                "rep": -0.3
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Secure case for documents 0052",
+                "number": 1,
+                "location": "Woods",
+                "id": 45
+            }
+        ],
+        "alternatives": [
+            25
+        ]
+    },
+    {
+        "id": 25,
+        "require": {
+            "level": 13,
+            "quests": [
+                23
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Skier",
+        "title": "Kind of sabotage",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Kind_of_sabotage",
+        "exp": 4600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": -0.1
+            },
+            {
+                "trader": "Skier",
+                "rep": 0.3
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Secure case for documents 0052",
+                "number": 1,
+                "location": "Woods",
+                "id": 46
+            }
+        ],
+        "alternatives": [
+            24
+        ]
+    },
+    {
+        "id": 26,
+        "require": {
+            "level": 10,
+            "quests": [
+                23
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "General wares",
+        "wiki": "https://escapefromtarkov.gamepedia.com/General_wares",
+        "exp": 5000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Can of beef stew",
+                "number": 15,
+                "location": "Any",
+                "id": 47
+            }
+        ]
+    },
+    {
+        "id": 27,
+        "require": {
+            "level": 10,
+            "quests": [
+                23
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Car repair",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Car_repair",
+        "exp": 7600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Car battery",
+                "number": 4,
+                "location": "Any",
+                "have": 0,
+                "id": 48
+            },
+            {
+                "type": "find",
+                "target": "Spark plug",
+                "number": 8,
+                "location": "Any",
+                "have": 0,
+                "id": 49
+            }
+        ]
+    },
+    {
+        "id": 28,
+        "require": {
+            "level": 10,
+            "quests": [
+                23
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Health Care Privacy - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_1",
+        "exp": 6500,
+        "unlocks": [
+            "IFAK personal tactical first aid kit"
+        ],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Ambulance 1",
+                "hint": "Resort",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 50
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Ambulance 2",
+                "hint": "Tunnel close",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 51
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Ambulance 3",
+                "hint": "Tunnel far",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 52
+            }
+        ]
+    },
+    {
+        "id": 29,
+        "require": {
+            "level": 10,
+            "quests": [
+                28
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Health Care Privacy - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_2",
+        "exp": 8600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "West wing room 306 key",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 53
+            },
+            {
+                "type": "pickup",
+                "target": "Secure case for documents 0060",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 54
+            }
+        ]
+    },
+    {
+        "id": 30,
+        "require": {
+            "level": 10,
+            "quests": [
+                29
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Health Care Privacy - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_3",
+        "exp": 9400,
+        "unlocks": [
+            "Morphine injector"
+        ],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Blood sample",
+                "number": 1,
+                "location": "Woods",
+                "id": 55
+            }
+        ]
+    },
+    {
+        "id": 31,
+        "require": {
+            "level": 10,
+            "quests": [
+                30
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Health Care Privacy - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_4",
+        "exp": 10200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Health",
+                "number": 4,
+                "location": "Any",
+                "id": 56
+            }
+        ]
+    },
+    {
+        "id": 32,
+        "require": {
+            "level": 10,
+            "quests": [
+                31
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Health Care Privacy - Part 5",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Health_Care_Privacy_-_Part_5",
+        "exp": 13300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "place",
+                "target": "Gunpowder \"Kite\"",
+                "number": 3,
+                "location": "Factory",
+                "id": 57
+            }
+        ]
+    },
+    {
+        "id": 33,
+        "require": {
+            "level": 30,
+            "quests": [
+                32,
+                34
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Decontamination Service",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Decontamination_service",
+        "exp": 21600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.11
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 40,
+                "location": "Interchange",
+                "with": [
+                    "Respirator OR Gasmask",
+                    "Close range"
+                ],
+                "id": 58
+            }
+        ]
+    },
+    {
+        "id": 34,
+        "require": {
+            "level": 35,
+            "quests": [
+                31
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Private clinic",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Private_clinic",
+        "exp": 20100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.11
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Ophthalmoscope",
+                "number": 1,
+                "location": "Any",
+                "id": 59
+            },
+            {
+                "type": "find",
+                "target": "LEDX Skin Transilluminator",
+                "number": 1,
+                "location": "Any",
+                "id": 60
+            }
+        ]
+    },
+    {
+        "id": 35,
+        "require": {
+            "level": 30,
+            "quests": [
+                31
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Athlete",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Athlete",
+        "exp": 19600,
+        "unlocks": [
+            "Adrenaline injector"
+        ],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.11
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Health",
+                "number": 10,
+                "location": "Any",
+                "id": 61
+            }
+        ]
+    },
+    {
+        "id": 36,
+        "require": {
+            "level": 5,
+            "quests": []
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Supplier",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Supplier",
+        "exp": 3300,
+        "unlocks": [
+            "Saiga-9 9x19 Carbine"
+        ],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Module-3M bodyarmor",
+                "number": 1,
+                "location": "Any",
+                "id": 62
+            },
+            {
+                "type": "find",
+                "target": "TOZ-106 bolt-action shotgun",
+                "number": 1,
+                "location": "Any",
+                "id": 63
+            }
+        ]
+    },
+    {
+        "id": 37,
+        "require": {
+            "level": 7,
+            "quests": [
+                36
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "The Extortionist",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Extortionist",
+        "exp": 3200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Unknown key",
+                "number": 1,
+                "location": "Customs",
+                "id": 64
+            },
+            {
+                "type": "pickup",
+                "target": "Docs 0048",
+                "number": 1,
+                "location": "Customs",
+                "id": 65
+            }
+        ]
+    },
+    {
+        "id": 38,
+        "require": {
+            "level": 8,
+            "quests": [
+                37
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "What's on the flash drive?",
+        "wiki": "https://escapefromtarkov.gamepedia.com/What%27s_on_the_flash_drive%3F",
+        "exp": 4500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.1
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Secure Flash drive",
+                "number": 2,
+                "location": "Any",
+                "id": 66
+            }
+        ]
+    },
+    {
+        "id": 39,
+        "require": {
+            "level": 8,
+            "quests": [
+                38
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Golden swag",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Golden_swag",
+        "exp": 4600,
+        "unlocks": [
+            "VOMZ Pilad P1X42 \"WEAVER\" reflex sight"
+        ],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Dorm room 303 Key",
+                "number": 1,
+                "location": "Customs",
+                "id": 67
+            },
+            {
+                "type": "key",
+                "target": "Trailer park cabin key",
+                "number": 1,
+                "location": "Customs",
+                "id": 68
+            },
+            {
+                "type": "pickup",
+                "target": "Gilded Zibbo lighter",
+                "number": 1,
+                "location": "Customs",
+                "id": 69
+            },
+            {
+                "type": "place",
+                "target": "Gilded Zibbo lighter",
+                "number": 1,
+                "location": "Customs",
+                "id": 70
+            }
+        ]
+    },
+    {
+        "id": 40,
+        "require": {
+            "level": 10,
+            "quests": [
+                39
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Chemical - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Chemical_-_Part_1",
+        "exp": 4800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Dorm room 220 Key",
+                "number": 1,
+                "location": "Customs",
+                "id": 71
+            },
+            {
+                "type": "pickup",
+                "target": "Docs 0013",
+                "number": 1,
+                "location": "Customs",
+                "id": 72
+            }
+        ]
+    },
+    {
+        "id": 41,
+        "require": {
+            "level": 10,
+            "quests": [
+                40
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Chemical - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Chemical_-_Part_2",
+        "exp": 4900,
+        "unlocks": [
+            "SAI-02 10-round 12x76 magazine for SOK-12 and compatible weapons"
+        ],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Dorm room 220 Key",
+                "number": 1,
+                "location": "Customs",
+                "id": 73
+            },
+            {
+                "type": "pickup",
+                "target": "Sealed letter (TerraGroup)",
+                "number": 1,
+                "location": "Customs",
+                "id": 74
+            },
+            {
+                "type": "pickup",
+                "target": "Sliderkey Secure Flash drive",
+                "number": 1,
+                "location": "Customs",
+                "id": 75
+            }
+        ]
+    },
+    {
+        "id": 42,
+        "require": {
+            "level": 11,
+            "quests": [
+                41
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Chemical - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Chemical_-_Part_3",
+        "exp": 5400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.08
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Syringe with a chemical",
+                "number": 1,
+                "location": "Factory",
+                "id": 76
+            }
+        ]
+    },
+    {
+        "id": 43,
+        "require": {
+            "level": 11,
+            "quests": [
+                42
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Chemical - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Chemical_-_Part_4",
+        "exp": 6600,
+        "unlocks": [
+            "ZSh-1-2M helmet (black)"
+        ],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.1
+            },
+            {
+                "trader": "Therapist",
+                "rep": -0.3
+            },
+            {
+                "trader": "Prapor",
+                "rep": -0.15
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Transport van",
+                "number": 1,
+                "location": "Customs",
+                "id": 77
+            }
+        ],
+        "alternatives": [
+            179,
+            180
+        ]
+    },
+    {
+        "id": 44,
+        "require": {
+            "level": 22,
+            "quests": [
+                42
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "\"Vitamins\" - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22Vitamins%22_-_Part_1",
+        "exp": 14100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.1
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Office 112 West wing key",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 78
+            },
+            {
+                "type": "key",
+                "target": "Key to EMERCOM medical unit",
+                "number": 1,
+                "location": "Interchange",
+                "id": 79
+            },
+            {
+                "type": "pickup",
+                "target": "Chemical container",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 80
+            },
+            {
+                "type": "pickup",
+                "target": "Chemical container",
+                "hint": "Mantis",
+                "number": 1,
+                "location": "Interchange",
+                "id": 81
+            },
+            {
+                "type": "pickup",
+                "target": "Chemical container",
+                "hint": "Emercom",
+                "number": 1,
+                "location": "Interchange",
+                "id": 82
+            }
+        ]
+    },
+    {
+        "id": 45,
+        "require": {
+            "level": 22,
+            "quests": [
+                44
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "\"Vitamins\" - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22Vitamins%22_-_Part_2",
+        "exp": 17200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Respirator",
+                "number": 4,
+                "location": "Any",
+                "id": 83
+            },
+            {
+                "type": "find",
+                "target": "Medical bloodset",
+                "number": 3,
+                "location": "Any",
+                "id": 84
+            }
+        ]
+    },
+    {
+        "id": 46,
+        "require": {
+            "level": 9,
+            "quests": [
+                39
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Friend from the West - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Friend_from_the_West_-_Part_1",
+        "exp": 10800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.14
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 7,
+                "location": "Any",
+                "with": [
+                    "USEC faction"
+                ],
+                "id": 303
+            },
+            {
+                "type": "find",
+                "target": "USEC dogtags",
+                "number": 7,
+                "location": "Any",
+                "id": 85
+            }
+        ]
+    },
+    {
+        "id": 47,
+        "require": {
+            "level": 9,
+            "quests": [
+                46
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Friend from the West - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Friend_from_the_West_-_Part_2",
+        "exp": 9200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "collect",
+                "target": "Dollars",
+                "number": 6000,
+                "location": "Any",
+                "id": 87
+            }
+        ]
+    },
+    {
+        "id": 48,
+        "require": {
+            "level": 25,
+            "quests": [
+                47
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Lend lease - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Lend_lease_-_Part_1",
+        "exp": 20000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "West wing room 216",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 88
+            },
+            {
+                "type": "key",
+                "target": "East wing room 306 OR 308 key",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 89
+            },
+            {
+                "type": "pickup",
+                "target": "Motor Controller",
+                "hint": "SUV",
+                "number": 1,
+                "location": "Woods",
+                "id": 90
+            },
+            {
+                "type": "pickup",
+                "target": "Motor Controller",
+                "hint": "By Eastern drone",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 91
+            },
+            {
+                "type": "pickup",
+                "target": "Motor Controller",
+                "hint": "East 306/308",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 92
+            },
+            {
+                "type": "pickup",
+                "target": "Single-axis Fiber Optic Gyroscope",
+                "hint": "West 216",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 93
+            },
+            {
+                "type": "pickup",
+                "target": "Single-axis Fiber Optic Gyroscope",
+                "hint": "Truck bed",
+                "number": 1,
+                "location": "Woods",
+                "id": 94
+            }
+        ]
+    },
+    {
+        "id": 49,
+        "require": {
+            "level": 30,
+            "quests": [
+                48
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Lend lease - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Lend_lease_-_Part_2",
+        "exp": 22200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Virtex programmable processor",
+                "number": 2,
+                "location": "Any",
+                "id": 95
+            },
+            {
+                "type": "find",
+                "target": "Military COFDM wireless Signal Transmitter",
+                "number": 1,
+                "location": "Any",
+                "id": 96
+            }
+        ]
+    },
+    {
+        "id": 50,
+        "require": {
+            "level": 30,
+            "quests": [
+                49
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Peacekeeping mission",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Peacekeeping_mission",
+        "exp": 32400,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 12,
+                "location": "Customs",
+                "with": [
+                    "UNTAR helmet",
+                    "MF-UNTAR armor vest",
+                    "Colt M4A1"
+                ],
+                "id": 97
+            },
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 12,
+                "location": "Interchange",
+                "with": [
+                    "UNTAR helmet",
+                    "MF-UNTAR armor vest",
+                    "Colt M4A1"
+                ],
+                "id": 98
+            },
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 12,
+                "location": "Shoreline",
+                "with": [
+                    "UNTAR helmet",
+                    "MF-UNTAR armor vest",
+                    "Colt M4A1"
+                ],
+                "id": 99
+            },
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 12,
+                "location": "Woods",
+                "with": [
+                    "UNTAR helmet",
+                    "MF-UNTAR armor vest",
+                    "Colt M4A1"
+                ],
+                "id": 100
+            }
+        ]
+    },
+    {
+        "id": 51,
+        "require": {
+            "level": 24,
+            "quests": [
+                47
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Informed means armed",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Informed_means_armed",
+        "exp": 15900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "WIFI Camera",
+                "target": "Brutal",
+                "number": 1,
+                "location": "Interchange",
+                "id": 101
+            },
+            {
+                "type": "mark",
+                "tool": "WIFI Camera",
+                "target": "Pier",
+                "number": 1,
+                "location": "Woods",
+                "id": 102
+            },
+            {
+                "type": "mark",
+                "tool": "WIFI Camera",
+                "target": "Roadblock",
+                "number": 1,
+                "location": "Customs",
+                "id": 103
+            }
+        ]
+    },
+    {
+        "id": 52,
+        "require": {
+            "level": 27,
+            "quests": [
+                51
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Chumming",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Chumming",
+        "exp": 22000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "place",
+                "target": "Golden neck chain",
+                "number": 3,
+                "location": "Interchange",
+                "id": 104
+            },
+            {
+                "type": "place",
+                "target": "Golden neck chain",
+                "number": 3,
+                "location": "Woods",
+                "id": 105
+            },
+            {
+                "type": "place",
+                "target": "Golden neck chain",
+                "number": 3,
+                "location": "Customs",
+                "id": 106
+            },
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 5,
+                "with": [
+                    "Between 22 and 10 hours"
+                ],
+                "location": "Interchange",
+                "id": 304
+            }
+        ]
+    },
+    {
+        "id": 53,
+        "require": {
+            "level": 27,
+            "quests": [
+                52
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Silent caliber",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Silent_caliber",
+        "exp": 12900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 20,
+                "location": "Any",
+                "with": [
+                    "supressed 12 gauge shotgun"
+                ],
+                "id": 107
+            },
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 10,
+                "location": "Any",
+                "with": [
+                    "supressed 12 gauge shotgun"
+                ],
+                "id": 108
+            }
+        ]
+    },
+    {
+        "id": 54,
+        "require": {
+            "level": 27,
+            "quests": [
+                52
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Flint",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Flint",
+        "exp": 20000,
+        "unlocks": [
+            "M-2 Tactical Sword"
+        ],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Stress Resistance",
+                "number": 6,
+                "location": "Any",
+                "id": 109
+            }
+        ]
+    },
+    {
+        "id": 55,
+        "require": {
+            "level": 27,
+            "quests": [
+                52
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Bullshit",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Bullshit",
+        "exp": 29700,
+        "unlocks": [
+            "5 pcs. 12x70 DIPP ammo box"
+        ],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "warning",
+                "target": "Do not kill any scavs from quest accept to quest complete",
+                "number": 1,
+                "location": "Customs",
+                "id": 110
+            },
+            {
+                "type": "pickup",
+                "target": "False flash drive",
+                "number": 1,
+                "location": "Customs",
+                "id": 111
+            },
+            {
+                "type": "place",
+                "target": "False flash drive",
+                "number": 1,
+                "location": "Customs",
+                "id": 112
+            },
+            {
+                "type": "place",
+                "target": "Roler submariner gold wrist watch",
+                "number": 1,
+                "location": "Customs",
+                "id": 113
+            },
+            {
+                "type": "place",
+                "target": "SV-98 bolt-action sniper rifle",
+                "number": 1,
+                "location": "Customs",
+                "id": 114
+            }
+        ]
+    },
+    {
+        "id": 56,
+        "require": {
+            "level": 27,
+            "quests": [
+                55
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Setup",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Setup",
+        "exp": 29300,
+        "unlocks": [
+            "20 pcs. 9x19 mm DIPP ammo box"
+        ],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 15,
+                "location": "Customs",
+                "with": [
+                    "MP Series shotgun",
+                    "Ushanka ear-flap cap",
+                    "Scav vest"
+                ],
+                "id": 115
+            }
+        ]
+    },
+    {
+        "id": 57,
+        "require": {
+            "level": 10,
+            "quests": [
+                47
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Fishing Gear",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Fishing_Gear",
+        "exp": 5400,
+        "unlocks": [
+            "Aimpoint Micro T-1 reflex sight"
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "place",
+                "target": "SV-98 bolt-action sniper rifle",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 116
+            },
+            {
+                "type": "place",
+                "target": "Leatherman Multitool",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 117
+            }
+        ]
+    },
+    {
+        "id": 58,
+        "require": {
+            "level": 10,
+            "quests": [
+                57
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Tigr Safari",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Tigr_Safari",
+        "exp": 6600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tigr vehicle 1",
+                "hint": "Checkpoint",
+                "number": 1,
+                "location": "Customs",
+                "id": 118
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tigr vehicle 2",
+                "hint": "Gas station",
+                "number": 1,
+                "location": "Customs",
+                "id": 119
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tigr vehicle 3",
+                "hint": "Bridge",
+                "number": 1,
+                "location": "Customs",
+                "id": 120
+            }
+        ]
+    },
+    {
+        "id": 59,
+        "require": {
+            "level": 10,
+            "quests": [
+                58
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Scrap Metal",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Scrap_Metal",
+        "exp": 7200,
+        "unlocks": [
+            "HK MP5 9x19 submachinegun (Navy 3 Round Burst) \"SD\""
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "T-90 tank 1",
+                "hint": "Bunker",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 121
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "T-90 tank 2",
+                "hint": "Town",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 122
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "T-90 tank 3",
+                "hint": "Weather station",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 123
+            }
+        ]
+    },
+    {
+        "id": 60,
+        "require": {
+            "level": 11,
+            "quests": [
+                59
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Eagle Eye",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Eagle_Eye",
+        "exp": 7300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "SAS disk 1",
+                "hint": "East Drone",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 124
+            },
+            {
+                "type": "pickup",
+                "target": "SAS disk 2",
+                "hint": "North Drone",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 125
+            }
+        ]
+    },
+    {
+        "id": 61,
+        "require": {
+            "level": 11,
+            "quests": [
+                60
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Humanitarian Supplies",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Humanitarian_Supplies",
+        "exp": 7400,
+        "unlocks": [
+            "Hexagon AK-74 5.45x39 sound suppressor"
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Un cargo truck 1",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 126
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Un cargo truck 2",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 127
+            },
+            {
+                "type": "collect",
+                "target": "MRE lunch box",
+                "number": 5,
+                "location": "Any",
+                "id": 128
+            },
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 10,
+                "location": "Shoreline",
+                "with": [
+                    "MF-UNTAR armor vest",
+                    "UNTAR helmet"
+                ],
+                "id": 129
+            }
+        ]
+    },
+    {
+        "id": 62,
+        "require": {
+            "level": 12,
+            "quests": [
+                61
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "The Cult - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Cult_-_Part_1",
+        "exp": 6700,
+        "unlocks": [
+            "5.56x45 mm M856A1"
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "The missing informant",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 130
+            }
+        ]
+    },
+    {
+        "id": 63,
+        "require": {
+            "level": 12,
+            "quests": [
+                62
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "The Cult - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Cult_-_Part_2",
+        "exp": 8200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Marked key",
+                "number": 1,
+                "location": "Customs",
+                "id": 131
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Ritual spot",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 132
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Ritual spot 1",
+                "hint": "Cabins",
+                "number": 1,
+                "location": "Woods",
+                "id": 133
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Ritual spot 2",
+                "hint": "Checkpoint",
+                "number": 1,
+                "location": "Woods",
+                "id": 268
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Ritual spot",
+                "number": 1,
+                "location": "Customs",
+                "id": 134
+            }
+        ]
+    },
+    {
+        "id": 64,
+        "require": {
+            "level": 12,
+            "quests": [
+                61
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Spa Tour - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_1",
+        "exp": 8900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 7,
+                "location": "Shoreline",
+                "with": [
+                    "12 gauge shotgun headshots"
+                ],
+                "id": 135
+            }
+        ]
+    },
+    {
+        "id": 65,
+        "require": {
+            "level": 12,
+            "quests": [
+                64
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Spa Tour - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_2",
+        "exp": 7500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Helicopter",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 136
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Safe road",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 137
+            }
+        ]
+    },
+    {
+        "id": 66,
+        "require": {
+            "level": 12,
+            "quests": [
+                65
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Spa Tour - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_3",
+        "exp": 9100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "WD-40 100ml",
+                "number": 1,
+                "location": "Any",
+                "id": 138
+            },
+            {
+                "type": "find",
+                "target": "Clin wiper",
+                "number": 2,
+                "location": "Any",
+                "id": 139
+            },
+            {
+                "type": "find",
+                "target": "Corrugated hose",
+                "number": 2,
+                "location": "Any",
+                "id": 140
+            },
+            {
+                "type": "find",
+                "target": "Ox bleach",
+                "number": 2,
+                "location": "Any",
+                "id": 141
+            }
+        ]
+    },
+    {
+        "id": 67,
+        "require": {
+            "level": 12,
+            "quests": [
+                66
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Spa Tour - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_4",
+        "exp": 9300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "West wing room 219 OR 220 key",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 142
+            },
+            {
+                "type": "locate",
+                "target": "Generator 1",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 143
+            },
+            {
+                "type": "locate",
+                "target": "Generator 2",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 144
+            }
+        ]
+    },
+    {
+        "id": 68,
+        "require": {
+            "level": 12,
+            "quests": [
+                67
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Spa Tour - Part 5",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_5",
+        "exp": 7800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "The key to the closed premises of the sanatorium",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 145
+            }
+        ]
+    },
+    {
+        "id": 69,
+        "require": {
+            "level": 12,
+            "quests": [
+                68
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Spa Tour - Part 6",
+        "wiki": "",
+        "exp": 11400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "collect",
+                "target": "Dollars",
+                "number": 8000,
+                "location": "Any",
+                "id": 146
+            }
+        ]
+    },
+    {
+        "id": 70,
+        "require": {
+            "level": 12,
+            "quests": [
+                69
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Spa Tour - Part 7",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_7",
+        "exp": 11600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.09
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Morphine injector",
+                "number": 4,
+                "location": "Any",
+                "id": 147
+            },
+            {
+                "type": "find",
+                "target": "Heat-exchange alkali surface washer",
+                "number": 2,
+                "location": "Any",
+                "id": 148
+            },
+            {
+                "type": "find",
+                "target": "Corrugated hose",
+                "number": 2,
+                "location": "Any",
+                "id": 149
+            },
+            {
+                "type": "find",
+                "target": "5L propane tank",
+                "number": 2,
+                "location": "Any",
+                "id": 150
+            }
+        ]
+    },
+    {
+        "id": 71,
+        "require": {
+            "level": 12,
+            "quests": [
+                70
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Cargo X - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Cargo_X_-_Part_1",
+        "exp": 10400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "East wing room 306 OR 308 key",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 151
+            },
+            {
+                "type": "pickup",
+                "target": "Toughbook reinforced laptop",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 152
+            }
+        ]
+    },
+    {
+        "id": 72,
+        "require": {
+            "level": 12,
+            "quests": [
+                71
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Cargo X - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Cargo_X_-_Part_2",
+        "exp": 8600,
+        "unlocks": [
+            "KAC QDSS NT-4 5.56x45 silencer (Black)"
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Docs 0013",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 153
+            }
+        ]
+    },
+    {
+        "id": 73,
+        "require": {
+            "level": 12,
+            "quests": [
+                72
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Cargo X - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Cargo_X_-_Part_3",
+        "exp": 10700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Hidden Terragroup cargo",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 154
+            }
+        ]
+    },
+    {
+        "id": 74,
+        "require": {
+            "level": 14,
+            "quests": [
+                70
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Wet Job - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_1",
+        "exp": 13000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.09
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 10,
+                "location": "Shoreline",
+                "with": [
+                    "Supressed M4 or ADAR"
+                ],
+                "id": 155
+            }
+        ]
+    },
+    {
+        "id": 75,
+        "require": {
+            "level": 14,
+            "quests": [
+                74
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Wet Job - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_2",
+        "exp": 11700,
+        "unlocks": [
+            "Magpul PMAG D-60 5.56x45 60-round magazine"
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Fisher's dwelling",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 156
+            }
+        ]
+    },
+    {
+        "id": 76,
+        "require": {
+            "level": 14,
+            "quests": [
+                75
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Wet Job - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_3",
+        "exp": 9900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Artyom's car",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 157
+            }
+        ]
+    },
+    {
+        "id": 77,
+        "require": {
+            "level": 14,
+            "quests": [
+                76
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Wet Job - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_4",
+        "exp": 10000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Sliderkey Flash drive",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 158
+            }
+        ]
+    },
+    {
+        "id": 78,
+        "require": {
+            "level": 14,
+            "quests": [
+                77
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Wet Job - Part 5",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_5",
+        "exp": 10200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "East wing room 328 OR Health resort utility room key",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 159
+            },
+            {
+                "type": "pickup",
+                "target": "Working hard drive",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 160
+            }
+        ]
+    },
+    {
+        "id": 79,
+        "require": {
+            "level": 14,
+            "quests": [
+                78
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Wet Job - Part 6",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Wet_Job_-_Part_6",
+        "exp": 10400,
+        "unlocks": [
+            "7.62x51 mm M61"
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.06
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Sniper Rifles",
+                "number": 7,
+                "location": "Any",
+                "id": 161
+            }
+        ]
+    },
+    {
+        "id": 80,
+        "require": {
+            "level": 40,
+            "quests": [
+                79
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Psycho Sniper",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Psycho_Sniper",
+        "exp": 32400,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Sniper Rifles",
+                "number": 9,
+                "location": "Any",
+                "id": 162
+            }
+        ]
+    },
+    {
+        "id": 81,
+        "require": {
+            "level": 14,
+            "quests": [
+                79
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "The guide",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_guide",
+        "exp": 35100,
+        "unlocks": [
+            "Eotech HHS-1 sight Tan",
+            "SLAAP armor Plate (Tan)",
+            "Arsenal CWP 30-round 5.56x45 magazine for SLR-106 and compatible weapons"
+        ],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.12
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 82,
+        "require": {
+            "level": 10,
+            "quests": []
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_1",
+        "exp": 6500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 83,
+        "require": {
+            "level": 11,
+            "quests": [
+                82
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_2",
+        "exp": 6000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 84,
+        "require": {
+            "level": 12,
+            "quests": [
+                83
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_3",
+        "exp": 8000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.05
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 85,
+        "require": {
+            "level": 15,
+            "quests": [
+                84
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_4",
+        "exp": 10100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.05
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 86,
+        "require": {
+            "level": 17,
+            "quests": [
+                85
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 5",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_5",
+        "exp": 13900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 87,
+        "require": {
+            "level": 18,
+            "quests": [
+                86
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 6",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_6",
+        "exp": 13900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 88,
+        "require": {
+            "level": 19,
+            "quests": [
+                87
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 7",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_7",
+        "exp": 16000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 89,
+        "require": {
+            "level": 19,
+            "quests": [
+                88
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 8",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_8",
+        "exp": 16200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 90,
+        "require": {
+            "level": 20,
+            "quests": [
+                89
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 9",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_9",
+        "exp": 17300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 91,
+        "require": {
+            "level": 20,
+            "quests": [
+                90
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 10",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_10",
+        "exp": 17500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 92,
+        "require": {
+            "level": 20,
+            "quests": [
+                91
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 11",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_11",
+        "exp": 18600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 93,
+        "require": {
+            "level": 23,
+            "quests": [
+                92
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 12",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_12",
+        "exp": 14400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 94,
+        "require": {
+            "level": 25,
+            "quests": [
+                93
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 13",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_13",
+        "exp": 19000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.05
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 95,
+        "require": {
+            "level": 27,
+            "quests": [
+                94
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 14",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_14",
+        "exp": 20800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.05
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 96,
+        "require": {
+            "level": 29,
+            "quests": [
+                95
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 15",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_15",
+        "exp": 22600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.05
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 97,
+        "require": {
+            "level": 35,
+            "quests": [
+                96
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Gunsmith - Part 16",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gunsmith_-_Part_16",
+        "exp": 28500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": []
+    },
+    {
+        "id": 98,
+        "require": {
+            "level": 12,
+            "quests": [
+                83
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Signal - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Signal_-_Part_1",
+        "exp": 8500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "First signal source",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 163
+            },
+            {
+                "type": "locate",
+                "target": "Second signal source",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 164
+            }
+        ]
+    },
+    {
+        "id": 99,
+        "require": {
+            "level": 12,
+            "quests": [
+                98
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Signal - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Signal_-_Part_2",
+        "exp": 8700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "PC CPU",
+                "number": 3,
+                "location": "Any",
+                "id": 165
+            },
+            {
+                "type": "find",
+                "target": "Rechargeable battery",
+                "number": 3,
+                "location": "Any",
+                "id": 166
+            },
+            {
+                "type": "find",
+                "target": "Printed circuit board",
+                "number": 3,
+                "location": "Any",
+                "id": 167
+            },
+            {
+                "type": "find",
+                "target": "Broken GPhone",
+                "number": 3,
+                "location": "Any",
+                "id": 168
+            }
+        ]
+    },
+    {
+        "id": 100,
+        "require": {
+            "level": 15,
+            "quests": [
+                99
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Signal - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Signal_-_Part_3",
+        "exp": 11000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "Signal Jammer",
+                "target": "Antenna 1",
+                "hint": "Weather Station",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 169
+            },
+            {
+                "type": "mark",
+                "tool": "Signal Jammer",
+                "target": "Antenna 2",
+                "hint": "Radio tower",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 170
+            },
+            {
+                "type": "mark",
+                "tool": "Signal Jammer",
+                "target": "Antenna 3",
+                "hint": "West Resort Roof",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 171
+            }
+        ]
+    },
+    {
+        "id": 101,
+        "require": {
+            "level": 15,
+            "quests": [
+                100
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Signal - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Signal_-_Part_4",
+        "exp": 11100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Memory",
+                "number": 4,
+                "location": "Any",
+                "id": 172
+            }
+        ]
+    },
+    {
+        "id": 102,
+        "require": {
+            "level": 15,
+            "quests": [
+                99
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Scout",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Scout",
+        "exp": 9200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Factory exit 1",
+                "hint": "Main",
+                "number": 1,
+                "location": "Factory",
+                "id": 173
+            },
+            {
+                "type": "locate",
+                "target": "Factory exit 2",
+                "hint": "Forlifts",
+                "number": 1,
+                "location": "Factory",
+                "id": 174
+            },
+            {
+                "type": "locate",
+                "target": "Factory exit 3",
+                "hint": "Staging side",
+                "number": 1,
+                "location": "Factory",
+                "id": 175
+            }
+        ]
+    },
+    {
+        "id": 103,
+        "require": {
+            "level": 12,
+            "quests": [
+                98,
+                84
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Insider",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Insider",
+        "exp": 9300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "reputation",
+                "target": "Prapor",
+                "number": 3,
+                "location": "Any",
+                "id": 176
+            }
+        ]
+    },
+    {
+        "id": 104,
+        "require": {
+            "level": 12,
+            "quests": [
+                82
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Farming - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Farming_-_Part_1",
+        "exp": 8000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "place",
+                "target": "A set of tools",
+                "hint": "Forklifts",
+                "number": 1,
+                "location": "Factory",
+                "id": 177
+            },
+            {
+                "type": "place",
+                "target": "A set of tools",
+                "hint": "Glass hallway",
+                "number": 1,
+                "location": "Factory",
+                "id": 178
+            }
+        ]
+    },
+    {
+        "id": 105,
+        "require": {
+            "level": 12,
+            "quests": [
+                104
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Farming - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Farming_-_Part_2",
+        "exp": 6800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Powercord",
+                "number": 2,
+                "location": "Any",
+                "id": 179
+            },
+            {
+                "type": "find",
+                "target": "T-Shaped Plug",
+                "number": 4,
+                "location": "Any",
+                "id": 180
+            },
+            {
+                "type": "find",
+                "target": "Printed circuit board",
+                "number": 2,
+                "location": "Any",
+                "id": 181
+            }
+        ]
+    },
+    {
+        "id": 106,
+        "require": {
+            "level": 14,
+            "quests": [
+                105
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Farming - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Farming_-_Part_3",
+        "exp": 8100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Customs office key",
+                "number": 1,
+                "location": "Customs",
+                "id": 182
+            },
+            {
+                "type": "pickup",
+                "target": "Package with graphics cards",
+                "number": 1,
+                "location": "Customs",
+                "id": 183
+            }
+        ]
+    },
+    {
+        "id": 107,
+        "require": {
+            "level": 14,
+            "quests": [
+                106
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Farming - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Farming_-_Part_4",
+        "exp": 9800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Graphics card",
+                "number": 3,
+                "location": "Any",
+                "id": 184
+            },
+            {
+                "type": "find",
+                "target": "CPU Fan",
+                "number": 8,
+                "location": "Any",
+                "id": 185
+            }
+        ]
+    },
+    {
+        "id": 108,
+        "require": {
+            "level": 35,
+            "quests": [
+                107
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Import",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Import",
+        "exp": 42800,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "UHF RFID Reader",
+                "number": 1,
+                "location": "Any",
+                "id": 186
+            },
+            {
+                "type": "find",
+                "target": "VPX Flash Storage Module",
+                "number": 1,
+                "location": "Any",
+                "id": 187
+            }
+        ]
+    },
+    {
+        "id": 109,
+        "require": {
+            "level": 30,
+            "quests": [
+                107
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Fertilizers",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Fertilizers",
+        "exp": 19500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Wires",
+                "number": 5,
+                "location": "Any",
+                "id": 188
+            },
+            {
+                "type": "find",
+                "target": "Capacitors",
+                "number": 5,
+                "location": "Any",
+                "id": 189
+            }
+        ]
+    },
+    {
+        "id": 110,
+        "require": {
+            "level": 14,
+            "quests": [
+                106
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "A Shooter Born in Heaven",
+        "wiki": "https://escapefromtarkov.gamepedia.com/A_Shooter_Born_in_Heaven",
+        "exp": 39500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 3,
+                "location": "Woods",
+                "with": [
+                    "Headshot from more than 100 meters"
+                ],
+                "id": 190
+            },
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 3,
+                "location": "Reserve",
+                "with": [
+                    "Headshot from more than 100 meters"
+                ],
+                "id": 191
+            },
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 3,
+                "location": "Shoreline",
+                "with": [
+                    "Headshot from more than 100 meters"
+                ],
+                "id": 192
+            },
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 3,
+                "location": "Customs",
+                "with": [
+                    "Headshot from more than 100 meters"
+                ],
+                "id": 193
+            }
+        ]
+    },
+    {
+        "id": 111,
+        "require": {
+            "level": 15,
+            "quests": []
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Only business",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Only_business",
+        "exp": 6700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "reputation",
+                "target": "Ragman",
+                "number": 2,
+                "location": "Any",
+                "id": 194
+            }
+        ]
+    },
+    {
+        "id": 112,
+        "require": {
+            "level": 15,
+            "quests": [
+                111
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Big sale",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Big_sale",
+        "exp": 8900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "AVOKADO",
+                "number": 1,
+                "location": "Interchange",
+                "id": 195
+            },
+            {
+                "type": "locate",
+                "target": "KOSTIN",
+                "number": 1,
+                "location": "Interchange",
+                "id": 196
+            },
+            {
+                "type": "locate",
+                "target": "tRend",
+                "number": 1,
+                "location": "Interchange",
+                "id": 197
+            },
+            {
+                "type": "locate",
+                "target": "DINO CLOTHES",
+                "number": 1,
+                "location": "Interchange",
+                "id": 198
+            },
+            {
+                "type": "locate",
+                "target": "TOP BRAND",
+                "number": 1,
+                "location": "Interchange",
+                "id": 199
+            }
+        ]
+    },
+    {
+        "id": 113,
+        "require": {
+            "level": 15,
+            "quests": [
+                112
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "The Blood of War - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Blood_of_War_-_Part_1",
+        "exp": 7500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tanker 1",
+                "hint": "Behind Goshan",
+                "number": 1,
+                "location": "Interchange",
+                "id": 200
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tanker 2",
+                "hint": "Highway Checkpoint",
+                "number": 1,
+                "location": "Interchange",
+                "id": 201
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Tanker 3",
+                "hint": "Power Station",
+                "number": 1,
+                "location": "Interchange",
+                "id": 202
+            }
+        ]
+    },
+    {
+        "id": 114,
+        "require": {
+            "level": 15,
+            "quests": [
+                113
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Dressed to kill",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Dressed_to_kill",
+        "exp": 10200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Ushanka ear-flap cap",
+                "number": 2,
+                "location": "Any",
+                "id": 203
+            },
+            {
+                "type": "find",
+                "target": "Kinda cowboy hat",
+                "number": 2,
+                "location": "Any",
+                "id": 204
+            }
+        ]
+    },
+    {
+        "id": 115,
+        "require": {
+            "level": 15,
+            "quests": [
+                112
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Database - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Database_-_Part_1",
+        "exp": 11500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Goshan cargo manifest",
+                "number": 1,
+                "location": "Interchange",
+                "id": 205
+            },
+            {
+                "type": "pickup",
+                "target": "OLI cargo manifest",
+                "number": 1,
+                "location": "Interchange",
+                "id": 206
+            },
+            {
+                "type": "pickup",
+                "target": "IDEA cargo manifest",
+                "number": 1,
+                "location": "Interchange",
+                "id": 207
+            }
+        ]
+    },
+    {
+        "id": 116,
+        "require": {
+            "level": 15,
+            "quests": [
+                115
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Database - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Database_-_Part_2",
+        "exp": 11700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Key to OLI logistics department office",
+                "number": 1,
+                "location": "Interchange",
+                "id": 208
+            },
+            {
+                "type": "pickup",
+                "target": "OLI cargo route documents",
+                "number": 1,
+                "location": "Interchange",
+                "id": 209
+            }
+        ]
+    },
+    {
+        "id": 117,
+        "require": {
+            "level": 25,
+            "quests": [
+                116,
+                114
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Gratitude",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Gratitude",
+        "exp": 16300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "place",
+                "target": "Ghost balaclava",
+                "number": 1,
+                "location": "Woods",
+                "id": 210
+            },
+            {
+                "type": "place",
+                "target": "Shemagh",
+                "number": 1,
+                "location": "Woods",
+                "id": 211
+            },
+            {
+                "type": "place",
+                "target": "RayBench sunglasses",
+                "number": 1,
+                "location": "Woods",
+                "id": 212
+            },
+            {
+                "type": "place",
+                "target": "Round frame sunglasses",
+                "number": 1,
+                "location": "Woods",
+                "id": 213
+            }
+        ]
+    },
+    {
+        "id": 118,
+        "require": {
+            "level": 30,
+            "quests": [
+                117
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Sales Night",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Sales_Night",
+        "exp": 19800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "warning",
+                "target": "\"Survive\" Interchange 7 times (they do not have to be consecutive)",
+                "number": 7,
+                "location": "Interchange",
+                "id": 373
+            }
+        ]
+    },
+    {
+        "id": 119,
+        "require": {
+            "level": 40,
+            "quests": [
+                118
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Supervisor",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Supervisor",
+        "exp": 24100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "collect",
+                "target": "Key to Goshan cash register",
+                "number": 1,
+                "location": "Any",
+                "id": 214
+            }
+        ]
+    },
+    {
+        "id": 120,
+        "require": {
+            "level": 29,
+            "quests": [
+                117
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Hot Delivery",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Hot_delivery",
+        "exp": 25000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "place",
+                "target": "Peltor ComTac 2 headset",
+                "hint": "AVOKADO",
+                "number": 2,
+                "location": "Interchange",
+                "id": 215
+            },
+            {
+                "type": "place",
+                "target": "6B47 Ratnik-BSh Helmet",
+                "hint": "AVOKADO",
+                "number": 2,
+                "location": "Interchange",
+                "id": 216
+            },
+            {
+                "type": "place",
+                "target": "BNTI Gzhel-K armor",
+                "hint": "Front Stage",
+                "number": 2,
+                "location": "Interchange",
+                "id": 217
+            }
+        ]
+    },
+    {
+        "id": 121,
+        "require": {
+            "level": 29,
+            "quests": [
+                120
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Scavenger",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Scavenger",
+        "exp": 15400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.11
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Search",
+                "number": 9,
+                "location": "Any",
+                "id": 218
+            }
+        ]
+    },
+    {
+        "id": 122,
+        "require": {
+            "level": 15,
+            "quests": [
+                111
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Make ULTRA Great Again",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Make_ULTRA_Great_Again",
+        "exp": 9800,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 25,
+                "location": "Interchange",
+                "id": 219
+            }
+        ]
+    },
+    {
+        "id": 123,
+        "require": {
+            "level": 24,
+            "quests": [
+                116
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Minibus",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Minibus",
+        "exp": 16500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Minibus 1",
+                "hint": "Safe Room",
+                "number": 1,
+                "location": "Interchange",
+                "id": 220
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Minibus 2",
+                "hint": "Beside Ramp",
+                "number": 1,
+                "location": "Interchange",
+                "id": 221
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Minibus 3",
+                "hint": "Oli Containers",
+                "number": 1,
+                "location": "Interchange",
+                "id": 222
+            }
+        ]
+    },
+    {
+        "id": 124,
+        "require": {
+            "level": 25,
+            "quests": [
+                116
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Sew it good - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_1",
+        "exp": 12300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Ski hat with holes for eyes 1",
+                "number": 1,
+                "location": "Any",
+                "id": 223
+            },
+            {
+                "type": "find",
+                "target": "Pilgrim tourist backpack",
+                "number": 1,
+                "location": "Any",
+                "id": 224
+            }
+        ]
+    },
+    {
+        "id": 125,
+        "require": {
+            "level": 25,
+            "quests": [
+                124
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Sew it good - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_2",
+        "exp": 18700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "collect",
+                "target": "BNTI Gzhel-K armor 0-50% condition",
+                "number": 1,
+                "location": "Any",
+                "id": 225
+            },
+            {
+                "type": "collect",
+                "target": "BNTI Gzhel-K armor 50-100% condition",
+                "number": 1,
+                "location": "Any",
+                "id": 226
+            }
+        ]
+    },
+    {
+        "id": 126,
+        "require": {
+            "level": 25,
+            "quests": [
+                125
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Sew it good - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_3",
+        "exp": 19700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "collect",
+                "target": "6B43 Zabralo-Sh 6A Armor 0-50% condition",
+                "number": 1,
+                "location": "Any",
+                "id": 227
+            },
+            {
+                "type": "collect",
+                "target": "6B43 Zabralo-Sh 6A Armor 50-100% condition",
+                "number": 1,
+                "location": "Any",
+                "id": 228
+            }
+        ]
+    },
+    {
+        "id": 127,
+        "require": {
+            "level": 25,
+            "quests": [
+                126
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Sew it good - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Sew_it_good_-_Part_4",
+        "exp": 20700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Wartech gear rig",
+                "number": 2,
+                "location": "Any",
+                "id": 229
+            },
+            {
+                "type": "find",
+                "target": "BlackRock chest rig",
+                "number": 2,
+                "location": "Any",
+                "id": 230
+            }
+        ]
+    },
+    {
+        "id": 128,
+        "require": {
+            "level": 25,
+            "quests": [
+                127
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Charisma brings success",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Charisma_brings_success",
+        "exp": 12700,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Charisma",
+                "number": 10,
+                "location": "Any",
+                "id": 231
+            }
+        ]
+    },
+    {
+        "id": 129,
+        "require": {
+            "level": 25,
+            "quests": [
+                176
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "No fuss needed",
+        "wiki": "https://escapefromtarkov.gamepedia.com/No_fuss_needed",
+        "exp": 12900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "reputation",
+                "target": "Therapist",
+                "number": 3,
+                "location": "Any",
+                "id": 232
+            }
+        ]
+    },
+    {
+        "id": 130,
+        "require": {
+            "level": 23,
+            "quests": [
+                124
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "The Blood of War - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Blood_of_War_-_Part_2",
+        "exp": 15600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Fuel conditioner",
+                "number": 4,
+                "location": "Any",
+                "id": 233
+            }
+        ]
+    },
+    {
+        "id": 131,
+        "require": {
+            "level": 30,
+            "quests": [
+                130
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "The Blood of War - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_Blood_of_War_-_Part_3",
+        "exp": 21000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Fuel stash 1",
+                "hint": "Outskirts side",
+                "number": 1,
+                "location": "Woods",
+                "id": 234
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Fuel stash 2",
+                "hint": "Sniper rock",
+                "number": 1,
+                "location": "Woods",
+                "id": 235
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Fuel stash 3",
+                "hint": "Jaeger camp",
+                "number": 1,
+                "location": "Woods",
+                "id": 236
+            }
+        ]
+    },
+    {
+        "id": 132,
+        "require": {
+            "level": 27,
+            "quests": [
+                126
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Living high is not a crime - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Living_high_is_not_a_crime_-_Part_1",
+        "exp": 23000,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.09
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Bronze lion",
+                "number": 2,
+                "location": "Any",
+                "id": 237
+            },
+            {
+                "type": "find",
+                "target": "Horse figurine",
+                "number": 2,
+                "location": "Any",
+                "id": 238
+            },
+            {
+                "type": "find",
+                "target": "Cat figurine",
+                "number": 1,
+                "location": "Any",
+                "id": 239
+            },
+            {
+                "type": "find",
+                "target": "Roler submariner gold wrist watch",
+                "number": 1,
+                "location": "Any",
+                "id": 240
+            }
+        ]
+    },
+    {
+        "id": 133,
+        "require": {
+            "level": 27,
+            "quests": [
+                131
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Living high is not a crime - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Living_high_is_not_a_crime_-_Part_2",
+        "exp": 29600,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Antique teapot",
+                "number": 3,
+                "location": "Any",
+                "id": 241
+            },
+            {
+                "type": "find",
+                "target": "Antique vase",
+                "number": 2,
+                "location": "Any",
+                "id": 242
+            }
+        ]
+    },
+    {
+        "id": 134,
+        "require": {
+            "level": 2,
+            "quests": []
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Introduction",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Introduction",
+        "exp": 4500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Jaeger's message",
+                "number": 1,
+                "location": "Woods",
+                "id": 243
+            }
+        ]
+    },
+    {
+        "id": 135,
+        "require": {
+            "level": 2,
+            "quests": [
+                134
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Acquaintance",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Acquaintance",
+        "exp": 4000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Iskra lunch box",
+                "number": 3,
+                "location": "Any",
+                "id": 244
+            },
+            {
+                "type": "find",
+                "target": "Emelya rye croutons",
+                "number": 2,
+                "location": "Any",
+                "id": 245
+            },
+            {
+                "type": "find",
+                "target": "Can of delicious beef stew",
+                "number": 2,
+                "location": "Any",
+                "id": 246
+            }
+        ]
+    },
+    {
+        "id": 136,
+        "require": {
+            "level": 10,
+            "quests": [
+                135
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Unprotected, but dangerous",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Unprotected,_but_dangerous",
+        "exp": 7000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 5,
+                "location": "Woods",
+                "with": [
+                    "No body armor"
+                ],
+                "id": 247
+            }
+        ]
+    },
+    {
+        "id": 137,
+        "require": {
+            "level": 10,
+            "quests": [
+                135
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Thrifty",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Thrifty",
+        "exp": 6500,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "place",
+                "target": "Iskra lunch box",
+                "hint": "ZB-014",
+                "number": 1,
+                "location": "Woods",
+                "id": 248
+            },
+            {
+                "type": "place",
+                "target": "Bottle of water",
+                "hint": "ZB-014",
+                "number": 1,
+                "location": "Woods",
+                "id": 249
+            },
+            {
+                "type": "place",
+                "target": "Iskra lunch box",
+                "hint": "ZB-016",
+                "number": 1,
+                "location": "Woods",
+                "id": 250
+            },
+            {
+                "type": "place",
+                "target": "Bottle of water",
+                "hint": "ZB-016",
+                "number": 1,
+                "location": "Woods",
+                "id": 251
+            }
+        ]
+    },
+    {
+        "id": 138,
+        "require": {
+            "level": 10,
+            "quests": [
+                137
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Zhivchik",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Zhivchik",
+        "exp": 9000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "warning",
+                "target": "Gain the dehydrated status for 5 minutes",
+                "number": 1,
+                "location": "Any",
+                "id": 352
+            }
+        ]
+    },
+    {
+        "id": 139,
+        "require": {
+            "level": 10,
+            "quests": [
+                138
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Wounded beast",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Wounded_beast",
+        "exp": 10000,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 3,
+                "location": "Any",
+                "with": [
+                    "Suffering from pain effect"
+                ],
+                "id": 252
+            }
+        ]
+    },
+    {
+        "id": 140,
+        "require": {
+            "level": 10,
+            "quests": [
+                139
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Tough guy",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Tough_guy",
+        "exp": 12000,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 3,
+                "location": "Woods",
+                "with": [
+                    "In one raid",
+                    "No healing used"
+                ],
+                "id": 253
+            }
+        ]
+    },
+    {
+        "id": 141,
+        "require": {
+            "level": 20,
+            "quests": [
+                140
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Courtesy visit",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Courtesy_visit",
+        "exp": 10000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Priest house",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 254
+            },
+            {
+                "type": "locate",
+                "target": "Fisherman house",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 255
+            },
+            {
+                "type": "locate",
+                "target": "Chairman house",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 256
+            }
+        ]
+    },
+    {
+        "id": 142,
+        "require": {
+            "level": 28,
+            "quests": [
+                141
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Nostalgia",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Nostalgia",
+        "exp": 10000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Jaeger's photo album",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 257
+            }
+        ]
+    },
+    {
+        "id": 143,
+        "require": {
+            "level": 17,
+            "quests": [
+                86
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_1",
+        "exp": 18900,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 5,
+                "location": "Any",
+                "with": [
+                    "A bolt-action sniper rifle without scope",
+                    "At least 40 meters away"
+                ],
+                "id": 258
+            }
+        ]
+    },
+    {
+        "id": 144,
+        "require": {
+            "level": 17,
+            "quests": [
+                143
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_2",
+        "exp": 19200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Any",
+                "number": 3,
+                "location": "Any",
+                "with": [
+                    "A bolt-action sniper rifle",
+                    "Leg shots",
+                    "At least 40 meters away"
+                ],
+                "id": 259
+            },
+            {
+                "type": "kill",
+                "target": "Any",
+                "number": 2,
+                "location": "Any",
+                "with": [
+                    "A bolt-action sniper rifle",
+                    "head shots",
+                    "At least 40 meters away"
+                ],
+                "id": 260
+            }
+        ]
+    },
+    {
+        "id": 145,
+        "require": {
+            "level": 17,
+            "quests": [
+                144
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_3",
+        "exp": 16200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 3,
+                "location": "Any",
+                "with": [
+                    "A bolt-action sniper rifle",
+                    "Less than 25 meters away"
+                ],
+                "id": 261
+            }
+        ]
+    },
+    {
+        "id": 146,
+        "require": {
+            "level": 17,
+            "quests": [
+                145
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 4",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_4",
+        "exp": 16400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Sniper Rifles",
+                "number": 3,
+                "location": "Any",
+                "id": 262
+            }
+        ]
+    },
+    {
+        "id": 147,
+        "require": {
+            "level": 17,
+            "quests": [
+                146
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 5",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_5",
+        "exp": 20000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 8,
+                "location": "Customs",
+                "with": [
+                    "A bolt-action sniper rifle",
+                    "Between 21 and 05 hours"
+                ],
+                "id": 263
+            }
+        ]
+    },
+    {
+        "id": 148,
+        "require": {
+            "level": 17,
+            "quests": [
+                147
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 6",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_6",
+        "exp": 20300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 5,
+                "location": "Any",
+                "with": [
+                    "A bolt-action sniper rifle",
+                    "Must be sniper scavs"
+                ],
+                "id": 264
+            }
+        ]
+    },
+    {
+        "id": 149,
+        "require": {
+            "level": 17,
+            "quests": [
+                148
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 7",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_7",
+        "exp": 20700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 5,
+                "location": "Any",
+                "with": [
+                    "Supressed bolt-action sniper rifle",
+                    "At least 45 meters away"
+                ],
+                "id": 265
+            }
+        ]
+    },
+    {
+        "id": 150,
+        "require": {
+            "level": 17,
+            "quests": [
+                149
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The Tarkov shooter - Part 8",
+        "wiki": "https://escapefromtarkov.gamepedia.com/%22The_Tarkov_shooter%22_-_Part_8",
+        "exp": 25200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 3,
+                "location": "Woods",
+                "with": [
+                    "A bolt-action sniper rifle",
+                    "In a single raid"
+                ],
+                "id": 266
+            }
+        ]
+    },
+    {
+        "id": 151,
+        "require": {
+            "level": 17,
+            "quests": [
+                139
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Cold blooded",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Cold_blooded",
+        "exp": 11000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 2,
+                "location": "Any",
+                "with": [
+                    "Headshot",
+                    "While you have tremor effect"
+                ],
+                "id": 267
+            }
+        ]
+    },
+    {
+        "id": 152,
+        "require": {
+            "level": 10,
+            "quests": [
+                185
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Colleagues - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Colleagues_-_Part_2",
+        "exp": 13200,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Cottage back entrance key",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 321
+            },
+            {
+                "type": "pickup",
+                "target": "Sanitar's surgery kit",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 318
+            },
+            {
+                "type": "pickup",
+                "target": "Sanitar's ophthalmoscope",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 319
+            }
+        ]
+    },
+    {
+        "id": 153,
+        "require": {
+            "level": 10,
+            "quests": [
+                152,
+                186,
+                187
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Colleagues - Part 3",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Colleagues_-_Part_3",
+        "exp": 13200,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "warning",
+                "target": "Do not kill Sanitar",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 320
+            },
+            {
+                "type": "find",
+                "target": "AHF1-M",
+                "number": 1,
+                "location": "Any",
+                "id": 322
+            },
+            {
+                "type": "find",
+                "target": "3-(b-TG)",
+                "number": 1,
+                "location": "Any",
+                "id": 323
+            },
+            {
+                "type": "collect",
+                "target": "Blue keycard",
+                "number": 1,
+                "location": "Any",
+                "id": 324
+            },
+            {
+                "type": "collect",
+                "target": "Green keycard",
+                "number": 1,
+                "location": "Any",
+                "id": 325
+            }
+        ],
+        "alternatives": [
+            190
+        ]
+    },
+    {
+        "id": 154,
+        "require": {
+            "level": 17,
+            "quests": [
+                151
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Combat medic",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Combat_medic",
+        "exp": 14000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "skill",
+                "target": "Vitality",
+                "number": 5,
+                "location": "Any",
+                "id": 270
+            }
+        ]
+    },
+    {
+        "id": 155,
+        "require": {
+            "level": 25,
+            "quests": [
+                151
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Ambulance",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Ambulance",
+        "exp": 12000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "CMS surgery kit",
+                "number": 2,
+                "location": "Any",
+                "id": 271
+            },
+            {
+                "type": "find",
+                "target": "Portable defibrillator",
+                "number": 1,
+                "location": "Any",
+                "id": 272
+            }
+        ]
+    },
+    {
+        "id": 156,
+        "require": {
+            "level": 17,
+            "quests": [
+                139
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Secured perimeter",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Secured_perimeter",
+        "exp": 14000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 6,
+                "location": "Factory",
+                "with": [
+                    "In the office area"
+                ],
+                "id": 273
+            }
+        ]
+    },
+    {
+        "id": 157,
+        "require": {
+            "level": 17,
+            "quests": [
+                156
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Reserv",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Reserv",
+        "exp": 9000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Food storage",
+                "number": 1,
+                "location": "Reserve",
+                "id": 274
+            }
+        ]
+    },
+    {
+        "id": 158,
+        "require": {
+            "level": 17,
+            "quests": [
+                156
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Woods cleaning",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Woods_cleaning",
+        "exp": 18000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 30,
+                "location": "Any",
+                "id": 275
+            }
+        ]
+    },
+    {
+        "id": 159,
+        "require": {
+            "level": 17,
+            "quests": [
+                158
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Controller",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Controller",
+        "exp": 21000,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 2,
+                "location": "Any",
+                "with": [
+                    "While they are flashed"
+                ],
+                "id": 276
+            }
+        ]
+    },
+    {
+        "id": 160,
+        "require": {
+            "level": 17,
+            "quests": [
+                158
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Evil watchman",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Evil_watchman",
+        "exp": 21000,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 5,
+                "location": "Customs",
+                "with": [
+                    "In the dorms area"
+                ],
+                "id": 277
+            }
+        ]
+    },
+    {
+        "id": 161,
+        "require": {
+            "level": 17,
+            "quests": [
+                158
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Fishing place",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Fishing_place",
+        "exp": 15000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "TerraGroup Labs access keycard",
+                "number": 2,
+                "location": "Any",
+                "id": 278
+            }
+        ]
+    },
+    {
+        "id": 162,
+        "require": {
+            "level": 17,
+            "quests": [
+                156
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - The trophy",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_The_trophy",
+        "exp": 20000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Reshala",
+                "number": 1,
+                "location": "Customs",
+                "id": 279
+            },
+            {
+                "type": "find",
+                "target": "golden TT",
+                "number": 1,
+                "location": "Customs",
+                "id": 280
+            }
+        ]
+    },
+    {
+        "id": 163,
+        "require": {
+            "level": 17,
+            "quests": [
+                162
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Justice",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Justice",
+        "exp": 20000,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 3,
+                "location": "Customs",
+                "with": [
+                    "Reshala bodyguards"
+                ],
+                "id": 281
+            }
+        ]
+    },
+    {
+        "id": 164,
+        "require": {
+            "level": 17,
+            "quests": [
+                162
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Sell-out",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Sell-out",
+        "exp": 23000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Killa",
+                "number": 1,
+                "location": "Interchange",
+                "id": 282
+            },
+            {
+                "type": "find",
+                "target": "Killa's helmet",
+                "number": 1,
+                "location": "Interchange",
+                "id": 283
+            }
+        ]
+    },
+    {
+        "id": 165,
+        "require": {
+            "level": 17,
+            "quests": [
+                164
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Woods keeper",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Woods_keeper",
+        "exp": 25000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Shturman",
+                "number": 1,
+                "location": "Woods",
+                "id": 284
+            },
+            {
+                "type": "find",
+                "target": "Shturman's key",
+                "number": 1,
+                "location": "Woods",
+                "id": 285
+            }
+        ]
+    },
+    {
+        "id": 166,
+        "require": {
+            "level": 17,
+            "quests": [
+                165
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Eraser - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Eraser_-_Part_1",
+        "exp": 30000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Glukhar",
+                "number": 1,
+                "location": "Reserve",
+                "id": 286
+            }
+        ]
+    },
+    {
+        "id": 167,
+        "require": {
+            "level": 17,
+            "quests": [
+                166
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Eraser - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Eraser_-_Part_2",
+        "exp": 30000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 6,
+                "location": "Any",
+                "with": [
+                    "Raider scavs"
+                ],
+                "id": 287
+            }
+        ]
+    },
+    {
+        "id": 168,
+        "require": {
+            "level": 17,
+            "quests": [
+                165
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Hunting trip",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Hunting_trip",
+        "exp": 16000,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Shturman",
+                "number": 1,
+                "location": "Woods",
+                "with": [
+                    "Remington M700",
+                    "March Tactical 3-24x42 FPP scope"
+                ],
+                "id": 269
+            }
+        ]
+    },
+    {
+        "id": 169,
+        "require": {
+            "level": 6,
+            "quests": [
+                19
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Operation Aquarius - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Operation_Aquarius_-_Part_1",
+        "exp": 3400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            },
+            {
+                "trader": "Skier",
+                "rep": -0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Dorm room 206 Key",
+                "number": 1,
+                "location": "Customs",
+                "id": 289
+            },
+            {
+                "type": "locate",
+                "target": "The hidden water in 2-story dorms, room 206",
+                "number": 1,
+                "location": "Customs",
+                "id": 290
+            }
+        ]
+    },
+    {
+        "id": 170,
+        "require": {
+            "level": 6,
+            "quests": [
+                169
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Operation Aquarius - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Operation_Aquarius_-_Part_2",
+        "exp": 3400,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.09
+            },
+            {
+                "trader": "Skier",
+                "rep": -0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 15,
+                "location": "Customs",
+                "id": 291
+            }
+        ]
+    },
+    {
+        "id": 171,
+        "require": {
+            "level": 10,
+            "quests": [
+                39
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Polikhim hobo",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Polikhim_hobo",
+        "exp": 7000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 25,
+                "location": "Customs",
+                "id": 292
+            }
+        ]
+    },
+    {
+        "id": 172,
+        "require": {
+            "level": 25,
+            "quests": [
+                171
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Regulated materials",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Regulated_materials",
+        "exp": 0,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Military battery",
+                "number": 1,
+                "location": "Any",
+                "id": 293
+            },
+            {
+                "type": "find",
+                "target": "30-mil. shells for BMP cannon",
+                "number": 5,
+                "location": "Any",
+                "id": 294
+            }
+        ]
+    },
+    {
+        "id": 173,
+        "require": {
+            "level": 8,
+            "quests": [
+                37
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Stirrup",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Stirrup",
+        "exp": 4700,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.12
+            },
+            {
+                "trader": "Prapor",
+                "rep": -0.12
+            },
+            {
+                "trader": "Therapist",
+                "rep": -0.05
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "PMCs",
+                "number": 3,
+                "location": "Any",
+                "with": [
+                    "pistol"
+                ],
+                "id": 295
+            }
+        ]
+    },
+    {
+        "id": 174,
+        "require": {
+            "level": 14,
+            "quests": [
+                77
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Mentor",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Mentor",
+        "exp": 4700,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "collect",
+                "target": "Euros",
+                "number": 50000,
+                "location": "Any",
+                "id": 296
+            }
+        ]
+    },
+    {
+        "id": 175,
+        "require": {
+            "level": 12,
+            "quests": [
+                105
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "Bad habit",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Bad_habit",
+        "exp": 9000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Malboro cigarettes",
+                "number": 5,
+                "location": "Any",
+                "id": 297
+            },
+            {
+                "type": "find",
+                "target": "Strike cigarettes",
+                "number": 5,
+                "location": "Any",
+                "id": 298
+            },
+            {
+                "type": "find",
+                "target": "Wilston cigarettes",
+                "number": 5,
+                "location": "Any",
+                "id": 299
+            }
+        ]
+    },
+    {
+        "id": 176,
+        "require": {
+            "level": 26,
+            "quests": [
+                125
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "The key to success",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_key_to_success",
+        "exp": 18100,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Ragman",
+                "rep": 0.07
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Clothes design handbook Part 1",
+                "hint": "Oli side 2F",
+                "number": 1,
+                "location": "Interchange",
+                "id": 300
+            },
+            {
+                "type": "pickup",
+                "target": "Clothes design handbook Part 2",
+                "hint": "Idea side 1F",
+                "number": 1,
+                "location": "Interchange",
+                "id": 301
+            }
+        ]
+    },
+    {
+        "id": 177,
+        "require": {
+            "level": 20,
+            "quests": [
+                38
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Shady Business",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Shady_business",
+        "exp": 11000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Secure Flash drive",
+                "number": 3,
+                "location": "Any",
+                "id": 302
+            }
+        ]
+    },
+    {
+        "id": 178,
+        "require": {
+            "level": 10,
+            "quests": [
+                6
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Postman Pat - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Postman_Pat_-_Part_2",
+        "exp": 4200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.06
+            }
+        ],
+        "objectives": [
+            {
+                "type": "pickup",
+                "target": "Sealed letter",
+                "number": 1,
+                "location": "Factory",
+                "id": 13
+            }
+        ]
+    },
+    {
+        "id": 179,
+        "require": {
+            "level": 11,
+            "quests": [
+                42
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Out of curiosity",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Out_of_curiosity",
+        "exp": 8300,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": -0.3
+            },
+            {
+                "trader": "Therapist",
+                "rep": 0.3
+            },
+            {
+                "trader": "Prapor",
+                "rep": -0.15
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Transport van",
+                "number": 1,
+                "location": "Customs",
+                "id": 77
+            }
+        ],
+        "alternatives": [
+            43,
+            180
+        ]
+    },
+    {
+        "id": 180,
+        "require": {
+            "level": 11,
+            "quests": [
+                42
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Big customer",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Big_customer",
+        "exp": 8200,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": -0.3
+            },
+            {
+                "trader": "Therapist",
+                "rep": -0.3
+            },
+            {
+                "trader": "Prapor",
+                "rep": 0.1
+            },
+            {
+                "trader": "Jaeger",
+                "rep": -0.01
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Transport van",
+                "number": 1,
+                "location": "Customs",
+                "id": 77
+            }
+        ],
+        "alternatives": [
+            43,
+            179
+        ]
+    },
+    {
+        "id": 181,
+        "require": {
+            "quests": [
+                151
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "The survivalist path - Junkie",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Junkie",
+        "exp": 12000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 15,
+                "location": "Woods",
+                "with": [
+                    "Stimulants active"
+                ],
+                "id": 305
+            }
+        ]
+    },
+    {
+        "id": 182,
+        "require": {
+            "level": 40,
+            "quests": [
+                127
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Textile - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Textile_-_Part_1",
+        "exp": 0,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Aramid fiber cloth",
+                "number": 5,
+                "location": "Any",
+                "id": 306
+            },
+            {
+                "type": "find",
+                "target": "Ripstop cloth",
+                "number": 10,
+                "location": "Any",
+                "id": 307
+            },
+            {
+                "type": "find",
+                "target": "Paracord",
+                "number": 3,
+                "location": "Any",
+                "id": 308
+            }
+        ]
+    },
+    {
+        "id": 183,
+        "require": {
+            "level": 47,
+            "quests": [
+                182
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "Textile - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Textile_-_Part_2",
+        "exp": 0,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Fleece cloth",
+                "number": 10,
+                "location": "Any",
+                "id": 309
+            },
+            {
+                "type": "find",
+                "target": "Polyamide fabric Cordura",
+                "number": 10,
+                "location": "Any",
+                "id": 310
+            },
+            {
+                "type": "find",
+                "target": "KEKTAPE duct tape",
+                "number": 5,
+                "location": "Any",
+                "id": 311
+            }
+        ]
+    },
+    {
+        "id": 184,
+        "require": {
+            "level": 21,
+            "quests": [
+                8
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Anesthesia",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Anesthesia",
+        "exp": 12600,
+        "nokappa": true,
+        "unlocks": [
+            {
+                "trader": "Prapor",
+                "rep": 0.1
+            }
+        ],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Trading post 1",
+                "hint": "Cottages",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 312
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Trading post 2",
+                "hint": "Pier",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 313
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Trading post 3",
+                "hint": "Resort",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 314
+            }
+        ]
+    },
+    {
+        "id": 185,
+        "require": {
+            "level": 10,
+            "quests": [
+                26
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "Colleagues - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Colleagues_-_Part_1",
+        "exp": 12600,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Therapist",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Health resort group",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 315
+            },
+            {
+                "type": "locate",
+                "target": "Pier group",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 316
+            },
+            {
+                "type": "locate",
+                "target": "Cottage group",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 317
+            }
+        ]
+    },
+    {
+        "id": 186,
+        "require": {
+            "level": 21,
+            "quests": [
+                184
+            ]
+        },
+        "giver": "Skier",
+        "turnin": "Skier",
+        "title": "Rigged game",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Rigged_game",
+        "exp": 13200,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Skier",
+                "rep": 0.1
+            }
+        ],
+        "objectives": [
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Health resort Medical container",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 326
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Cottages Medical container",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 327
+            },
+            {
+                "type": "mark",
+                "tool": "MS2000 marker",
+                "target": "Pier Medical container",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 328
+            }
+        ]
+    },
+    {
+        "id": 187,
+        "require": {
+            "level": 21,
+            "quests": [
+                184,
+                185
+            ]
+        },
+        "giver": "Mechanic",
+        "turnin": "Mechanic",
+        "title": "The chemistry closet",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_chemistry_closet",
+        "exp": 13800,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Mechanic",
+                "rep": 0.14
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Key with tape",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 329
+            },
+            {
+                "type": "locate",
+                "target": "Sanitar's office",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 330
+            }
+        ]
+    },
+    {
+        "id": 188,
+        "require": {
+            "level": 21,
+            "quests": [
+                184,
+                185
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "Samples",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Samples",
+        "exp": 13200,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.12
+            }
+        ],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "M.U.L.E. stimulator",
+                "number": 1,
+                "location": "Any",
+                "id": 331
+            },
+            {
+                "type": "find",
+                "target": "Cocktail \"Obdolbos\"",
+                "number": 1,
+                "location": "Any",
+                "id": 332
+            },
+            {
+                "type": "find",
+                "target": "Meldonin",
+                "number": 1,
+                "location": "Any",
+                "id": 333
+            },
+            {
+                "type": "find",
+                "target": "AHF1-M",
+                "number": 1,
+                "location": "Any",
+                "id": 334
+            },
+            {
+                "type": "find",
+                "target": "P22",
+                "number": 1,
+                "location": "Any",
+                "id": 335
+            },
+            {
+                "type": "find",
+                "target": "L1 (Norepinephrine)",
+                "number": 1,
+                "location": "Any",
+                "id": 336
+            },
+            {
+                "type": "find",
+                "target": "3-(b-TG)",
+                "number": 1,
+                "location": "Any",
+                "id": 337
+            }
+        ]
+    },
+    {
+        "id": 189,
+        "require": {
+            "level": 21,
+            "quests": [
+                188,
+                190
+            ]
+        },
+        "giver": "Peacekeeper",
+        "turnin": "Peacekeeper",
+        "title": "TerraGroup employee",
+        "wiki": "https://escapefromtarkov.gamepedia.com/TerraGroup_employee",
+        "exp": 14400,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Peacekeeper",
+                "rep": 0.2
+            }
+        ],
+        "objectives": [
+            {
+                "type": "key",
+                "target": "Key card with a blue marking",
+                "number": 1,
+                "location": "Labs",
+                "id": 338
+            },
+            {
+                "type": "locate",
+                "target": "Sanitar's workplace",
+                "number": 1,
+                "location": "Labs",
+                "id": 339
+            },
+            {
+                "type": "pickup",
+                "target": "Marked with tape flash drive",
+                "number": 1,
+                "location": "Labs",
+                "id": 340
+            }
+        ]
+    },
+    {
+        "id": 190,
+        "require": {
+            "level": 21,
+            "quests": [
+                152,
+                186,
+                187
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Huntsman path - Sadist",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Huntsman_path_-_Sadist",
+        "exp": 13800,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.2
+            },
+            {
+                "trader": "Therapist",
+                "rep": -0.2
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Sanitar",
+                "number": 1,
+                "location": "Shoreline",
+                "id": 341
+            }
+        ],
+        "alternatives": [
+            153
+        ]
+    },
+    {
+        "id": 191,
+        "require": {
+            "level": 10,
+            "quests": [
+                4
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The bunker - Part 1",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_bunker_-_Part_1",
+        "exp": 6000,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Underground bunker",
+                "number": 1,
+                "location": "Reserve",
+                "id": 342
+            },
+            {
+                "type": "locate",
+                "target": "Bunker control room",
+                "number": 1,
+                "location": "Reserve",
+                "id": 343
+            }
+        ]
+    },
+    {
+        "id": 192,
+        "require": {
+            "level": 10,
+            "quests": [
+                191
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "The bunker - Part 2",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_bunker_-_Part_2",
+        "exp": 6600,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.08
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "White Bishop hermetic door",
+                "number": 1,
+                "location": "Reserve",
+                "id": 344
+            },
+            {
+                "type": "locate",
+                "target": "Black Bishop hermetic door",
+                "number": 1,
+                "location": "Reserve",
+                "id": 345
+            },
+            {
+                "type": "locate",
+                "target": "Black Pawn hermetic door",
+                "number": 1,
+                "location": "Reserve",
+                "id": 346
+            },
+            {
+                "type": "locate",
+                "target": "White Pawn hermetic door",
+                "number": 1,
+                "location": "Reserve",
+                "id": 347
+            },
+            {
+                "type": "locate",
+                "target": "White King hermetic door",
+                "number": 1,
+                "location": "Reserve",
+                "id": 348
+            }
+        ]
+    },
+    {
+        "id": 193,
+        "require": {
+            "level": 5,
+            "quests": [
+                0
+            ]
+        },
+        "giver": "Prapor",
+        "turnin": "Prapor",
+        "title": "Search mission",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Search_mission",
+        "exp": 2000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Prapor",
+                "rep": 0.04
+            }
+        ],
+        "objectives": [
+            {
+                "type": "locate",
+                "target": "Missing convoy",
+                "number": 1,
+                "location": "Woods",
+                "id": 349
+            },
+            {
+                "type": "locate",
+                "target": "Temporary USEC camp",
+                "number": 1,
+                "location": "Woods",
+                "id": 350
+            }
+        ]
+    },
+    {
+        "id": 194,
+        "require": {
+            "level": 26,
+            "quests": [
+                176
+            ]
+        },
+        "giver": "Ragman",
+        "turnin": "Ragman",
+        "title": "The stylish one",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_stylish_one",
+        "exp": 0,
+        "nokappa": true,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Killa",
+                "number": 100,
+                "location": "Interchange",
+                "id": 351
+            }
+        ]
+    },
+    {
+        "id": 196,
+        "require": {
+            "quests": [
+                151
+            ]
+        },
+        "giver": "Jaeger",
+        "turnin": "Jaeger",
+        "title": "Thee survivalist path - Eagle-owl",
+        "wiki": "https://escapefromtarkov.gamepedia.com/The_survivalist_path_-_Eagle-owl",
+        "exp": 13000,
+        "unlocks": [],
+        "reputation": [
+            {
+                "trader": "Jaeger",
+                "rep": 0.03
+            }
+        ],
+        "objectives": [
+            {
+                "type": "kill",
+                "target": "Scavs",
+                "number": 6,
+                "location": "Any",
+                "with": [
+                    "No NVG or Thermals",
+                    "Between 21 and 04 hours"
+                ],
+                "id": 288
+            }
+        ]
+    },
+    {
+        "id": 195,
+        "require": {
+            "level": 40,
+            "quests": [
+                2,
+                9,
+                11,
+                12,
+                18,
+                24,
+                25,
+                26,
+                27,
+                33,
+                35,
+                43,
+                45,
+                49,
+                53,
+                54,
+                56,
+                63,
+                73,
+                80,
+                81,
+                97,
+                101,
+                102,
+                103,
+                109,
+                110,
+                119,
+                121,
+                122,
+                123,
+                127,
+                129,
+                133,
+                136,
+                142,
+                150,
+                154,
+                155,
+                157,
+                161,
+                167,
+                170,
+                171,
+                173,
+                175,
+                177,
+                178,
+                179,
+                180,
+                181,
+                193,
+                196,
+                197
+            ]
+        },
+        "giver": "Fence",
+        "turnin": "Fence",
+        "title": "Collector",
+        "wiki": "https://escapefromtarkov.gamepedia.com/Collector",
+        "exp": 0,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "find",
+                "target": "Old firesteel",
+                "number": 1,
+                "location": "Any",
+                "id": 353
+            },
+            {
+                "type": "find",
+                "target": "Antique axe",
+                "number": 1,
+                "location": "Any",
+                "id": 354
+            },
+            {
+                "type": "find",
+                "target": "Battered antique Book",
+                "number": 1,
+                "location": "Any",
+                "id": 355
+            },
+            {
+                "type": "find",
+                "target": "FireKlean gun lube",
+                "number": 1,
+                "location": "Any",
+                "id": 356
+            },
+            {
+                "type": "find",
+                "target": "Golden rooster",
+                "number": 1,
+                "location": "Any",
+                "id": 357
+            },
+            {
+                "type": "find",
+                "target": "Silver Badge",
+                "number": 1,
+                "location": "Any",
+                "id": 358
+            },
+            {
+                "type": "find",
+                "target": "Deadlyslob's beard oil",
+                "number": 1,
+                "location": "Any",
+                "id": 359
+            },
+            {
+                "type": "find",
+                "target": "Golden 1GPhone",
+                "number": 1,
+                "location": "Any",
+                "id": 360
+            },
+            {
+                "type": "find",
+                "target": "Jar of DevilDog mayo",
+                "number": 1,
+                "location": "Any",
+                "id": 361
+            },
+            {
+                "type": "find",
+                "target": "Can of sprats",
+                "number": 1,
+                "location": "Any",
+                "id": 362
+            },
+            {
+                "type": "find",
+                "target": "Fake mustache",
+                "number": 1,
+                "location": "Any",
+                "id": 363
+            },
+            {
+                "type": "find",
+                "target": "Kotton beanie",
+                "number": 1,
+                "location": "Any",
+                "id": 364
+            },
+            {
+                "type": "find",
+                "target": "Can of Dr. Lupo's coffee beans",
+                "number": 1,
+                "location": "Any",
+                "id": 365
+            },
+            {
+                "type": "find",
+                "target": "Pestily plague mask",
+                "number": 1,
+                "location": "Any",
+                "id": 366
+            },
+            {
+                "type": "find",
+                "target": "Raven figurine",
+                "number": 1,
+                "location": "Any",
+                "id": 367
+            },
+            {
+                "type": "find",
+                "target": "Shroud half-mask",
+                "number": 1,
+                "location": "Any",
+                "id": 368
+            },
+            {
+                "type": "find",
+                "target": "Veritas guitar pick",
+                "number": 1,
+                "location": "Any",
+                "id": 369
+            },
+            {
+                "type": "find",
+                "target": "42nd Signature Blend English Tea",
+                "number": 1,
+                "location": "Any",
+                "id": 370
+            }
+        ]
+    },
+    {
+        "id": 197,
+        "require": {
+            "quests": [
+                30
+            ]
+        },
+        "giver": "Therapist",
+        "turnin": "Therapist",
+        "title": "An apple a day - keeps the doctor away",
+        "wiki": "https://escapefromtarkov.gamepedia.com/An_apple_a_day_-_keeps_the_doctor_away",
+        "exp": 0,
+        "unlocks": [],
+        "reputation": [],
+        "objectives": [
+            {
+                "type": "collect",
+                "target": "Rubles",
+                "number": 400000,
+                "location": "Any",
+                "id": 372
+            }
+        ]
+    }
 ]


### PR DESCRIPTION
Convert all references by quest title to ID references. Added CLI tool option to help with similar data management in the future.